### PR TITLE
feat: add component router, guild management, context helpers, and ne…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [2.7] — 2026-04-17
+
+New plugin, a modal shortcut, a global error handler, and expanded embed support.
+
+### New: `TagsPlugin`
+
+Per-guild text snippet store. Drop it in like any other plugin:
+
+```python
+from easycord.plugins import TagsPlugin
+bot.add_plugin(TagsPlugin())
+```
+
+Four slash commands: `/tag get`, `/tag set`, `/tag delete` (admin or creator), `/tag list`.
+Persists to `tags_<guild_id>.json` in the configured `data_dir`.
+
+### New: `ctx.prompt()`
+
+Single-field modal shortcut — replaces the verbose `ask_form` call for the common "ask one question" case:
+
+```python
+text = await ctx.prompt("What's your reason?", max_length=200)
+```
+
+Returns the entered string, or `None` on timeout/dismiss.
+
+### New: `@bot.on_error` decorator
+
+Register a global error handler for unhandled command exceptions without wiring `catch_errors()` middleware:
+
+```python
+@bot.on_error
+async def handle_error(ctx, error):
+    await ctx.respond(f"Something went wrong: {error}", ephemeral=True)
+```
+
+### `send_embed` extras
+
+Four new optional keyword arguments on `ctx.send_embed()`:
+
+| Param | Effect |
+| --- | --- |
+| `thumbnail="url"` | Small thumbnail in top-right corner |
+| `image="url"` | Large image below description |
+| `author="name"` or `author={name, icon_url, url}` | Author line above title |
+| `timestamp=True` | Current UTC timestamp; or pass a `datetime` |
+
+All four are backwards-compatible — existing calls are unaffected.
+
+### Component router, guild management, and context helpers
+
+- `@bot.component(custom_id)` — persistent button/select-menu routing with prefix matching
+- `_GuildMixin` — `fetch_guild`, `fetch_channel`, `leave_guild`, `create_channel`, `delete_channel`, `send_webhook`, `create_emoji`, `delete_emoji`, `fetch_guild_emojis`
+- `ctx.fetch_member`, `ctx.bot_permissions`, `ctx.typing()`, `ctx.fetch_pinned_messages()`
+- `boost_only()` and `has_permission()` middleware factories
+- `set_status`: `activity_type="streaming"` now creates a `discord.Streaming` activity
+
+---
+
 ## [2.6] — 2026-04-16
 
 Internal refactor and framework improvements. No breaking changes to the public API.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ EasyCord keeps the full power of discord.py within reach while removing the boil
 
 ---
 
+## Navigation
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Slash Commands](#slash-commands)
+- [Persistent Components](#persistent-components)
+- [Event Handling](#event-handling)
+- [Middleware](#middleware)
+- [Plugins](#plugins)
+- [Composer](#composer)
+- [Per-Guild Config](#per-guild-config)
+- [Guild and Channel Management](#guild-and-channel-management)
+- [API Reference](#api-reference)
+- [Creating a Bot Application](#creating-a-bot-application)
+
+---
+
 ## The Backstory
 
 This project wasn't just a coding exercise — it was a solution to a real problem. I founded and managed the Senior IT Program Discord server for my school.
@@ -198,7 +215,56 @@ async def my_command(ctx, member: discord.Member):
     deleted = await ctx.purge(10)
     messages = await ctx.fetch_messages(5)
     thread = await ctx.create_thread("Support: my issue")
+
+    # New helpers
+    member = await ctx.fetch_member(user_id)        # API fetch, no guild_id needed
+    perms = ctx.bot_permissions                      # bot's own permissions here
+    pins = await ctx.fetch_pinned_messages()         # pinned messages in this channel
+    async with ctx.typing():                         # show typing indicator
+        data = await slow_operation()
+        await ctx.respond(data)
 ```
+
+---
+
+## Persistent Components
+
+`@bot.component` routes button and select-menu interactions to a handler without any manual `on_interaction` wiring. Middleware runs on every component interaction automatically.
+
+### Basic (custom ID = function name)
+
+```python
+@bot.component
+async def confirm_ban(ctx):
+    await ctx.respond("Ban confirmed!", ephemeral=True)
+```
+
+Register the button elsewhere with `custom_id="confirm_ban"`.
+
+### Explicit custom ID
+
+```python
+@bot.component("yes_btn")
+async def yes_handler(ctx):
+    await ctx.respond("You clicked Yes.")
+```
+
+### Prefix matching — pass data through the custom ID
+
+End the registered ID with `_` to match any custom ID that starts with it. The suffix is passed as a second argument, eliminating the need to look up IDs from a separate store.
+
+```python
+@bot.component("ban_")
+async def ban_button(ctx, suffix: str):
+    # suffix = everything after "ban_", e.g. "ban_12345" → "12345"
+    member = await ctx.fetch_member(int(suffix))
+    confirmed = await ctx.confirm(f"Ban {member.display_name}?")
+    if confirmed:
+        await ctx.ban(member)
+        await ctx.respond(f"Banned {member.display_name}.")
+```
+
+Create the button with `custom_id=f"ban_{member.id}"` and the router does the rest.
 
 ---
 
@@ -237,16 +303,24 @@ Middleware is executed in the order it was registered.
 
 ```python
 from easycord.middleware import (
-    log_middleware,   # log every invocation
-    catch_errors,     # catch unhandled exceptions
-    rate_limit,       # per-user rate limiting
-    guild_only,       # block DM usage
+    log_middleware,    # log every invocation
+    catch_errors,      # catch unhandled exceptions
+    rate_limit,        # per-user sliding-window rate limit
+    guild_only,        # block DM usage
+    dm_only,           # block guild usage
+    admin_only,        # require administrator permission
+    allowed_roles,     # require one of a set of role IDs
+    channel_only,      # restrict to specific channels
+    boost_only,        # require server booster status
+    has_permission,    # require specific discord permissions
 )
 
 bot.use(log_middleware())
 bot.use(catch_errors(message="Something broke"))
 bot.use(rate_limit(limit=5, window=10))
 bot.use(guild_only())
+bot.use(boost_only())                                    # server boosters only
+bot.use(has_permission("kick_members", "ban_members"))   # require permissions
 ```
 
 ---
@@ -329,6 +403,43 @@ await store.save(cfg)
 
 ---
 
+## Guild and Channel Management
+
+Manage guilds, channels, webhooks, and emojis directly from the bot without touching discord.py internals.
+
+```python
+# Leave a guild
+await bot.leave_guild(guild_id)
+
+# Fetch guild or channel (cache-first)
+guild = await bot.fetch_guild(guild_id)
+channel = await bot.fetch_channel(channel_id)
+
+# Create / delete channels
+await bot.create_channel(guild_id, "announcements", channel_type="text", topic="News")
+await bot.create_channel(guild_id, "General", channel_type="voice")
+await bot.delete_channel(channel_id)
+
+# Send via webhook — creates and caches a webhook automatically, one call
+await bot.send_webhook(channel_id, "Server update!", username="NewsBot")
+
+# Emoji management
+emoji = await bot.create_emoji(guild_id, "cool", "cool.png")
+await bot.delete_emoji(guild_id, emoji.id)
+emojis = await bot.fetch_guild_emojis(guild_id)
+```
+
+### Bot presence — now with streaming
+
+```python
+await bot.set_status("online",  activity="your commands", activity_type="listening")
+await bot.set_status("idle",    activity="Maintenance",   activity_type="watching")
+await bot.set_status("dnd",     activity="live now",      activity_type="streaming")
+await bot.set_status("invisible")
+```
+
+---
+
 ## Expanding with AI
 
 Inside the repo there is a file called `model.md` — a "Single-Source Context Map" designed for AI agents.
@@ -378,7 +489,18 @@ pyproject.toml
 | `bot.use(middleware)` | Register a middleware function |
 | `bot.add_plugin(plugin)` | Load a `Plugin` instance |
 | `await bot.remove_plugin(plugin)` | Unload a plugin at runtime |
-| `await bot.set_status(status, *, activity, activity_type)` | Set the bot's presence status and activity text |
+| `@bot.component` / `@bot.component("id")` | Register a persistent button/select-menu handler |
+| `@bot.component("prefix_")` | Prefix-match handler — suffix passed as second arg |
+| `await bot.fetch_guild(guild_id)` | Cache-first guild fetch |
+| `await bot.fetch_channel(channel_id)` | Cache-first channel fetch |
+| `await bot.leave_guild(guild_id)` | Make the bot leave a guild |
+| `await bot.create_channel(guild_id, name, *, channel_type, ...)` | Create a text/voice/category/stage/forum channel |
+| `await bot.delete_channel(channel_id, *, reason)` | Delete a channel by ID |
+| `await bot.send_webhook(channel_id, content, *, username, embed, ...)` | One-shot webhook send (auto-creates and caches webhook) |
+| `await bot.create_emoji(guild_id, name, image_path)` | Create a custom emoji from a local file |
+| `await bot.delete_emoji(guild_id, emoji_id)` | Delete a custom emoji |
+| `await bot.fetch_guild_emojis(guild_id)` | Return all custom emojis for a guild |
+| `await bot.set_status(status, *, activity, activity_type)` | Status: `online/idle/dnd/invisible`; type: `playing/watching/listening/streaming` |
 | `await bot.fetch_member(guild_id, user_id)` | Fetch a `discord.Member` by guild + user ID |
 | `bot.run(token)` | Start the bot |
 
@@ -434,6 +556,10 @@ pyproject.toml
 | `await ctx.unreact(message, emoji)` | Remove the bot's own reaction |
 | `await ctx.clear_reactions(message)` | Remove all reactions |
 | `await ctx.delete_message(message, *, delay)` | Delete a message, optionally after a delay |
+| `await ctx.fetch_member(user_id)` | API fetch from within the command (no guild_id needed) |
+| `ctx.bot_permissions` | Bot's own `discord.Permissions` in the current channel |
+| `ctx.typing()` | Context manager — show typing indicator (`async with ctx.typing()`) |
+| `await ctx.fetch_pinned_messages()` | Return all pinned messages in the current channel |
 
 ### `Plugin`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,13 +36,41 @@
 
 `await Bot.remove_plugin(plugin)` — unload plugin; removes commands, deregisters handlers, calls `on_unload()`
 
+### Guild / Channel / Webhook / Emoji
+
+`await Bot.fetch_guild(guild_id)` → `discord.Guild` — cache-first; raises `discord.NotFound`
+
+`await Bot.fetch_channel(channel_id)` → channel — cache-first; raises `discord.NotFound` / `discord.Forbidden`
+
+`await Bot.leave_guild(guild_id)` — leave a guild; raises `RuntimeError` if not a member
+
+`await Bot.create_channel(guild_id, name, *, channel_type="text", category_id=None, topic=None, reason=None)` → channel — `channel_type`: `"text" | "voice" | "category" | "stage" | "forum"`
+
+`await Bot.delete_channel(channel_id, *, reason=None)`
+
+`await Bot.send_webhook(channel_id, content=None, *, username=None, avatar_url=None, embed=None, **kwargs)` — one-shot webhook send; creates and caches a webhook on first use per channel
+
+`await Bot.create_emoji(guild_id, name, image_path, *, reason=None)` → `discord.Emoji`
+
+`await Bot.delete_emoji(guild_id, emoji_id, *, reason=None)`
+
+`await Bot.fetch_guild_emojis(guild_id)` → `list[discord.Emoji]`
+
+### Component routing
+
+`@Bot.component` / `@Bot.component("custom_id")` — register a persistent button/select-menu handler; custom ID defaults to function name
+
+`@Bot.component("prefix_")` — prefix match: `"prefix_suffix"` invokes handler with `(ctx, "suffix")`
+
+Middleware runs on component interactions exactly as it does for slash commands.
+
 ### Lookup / Presence / Run
 
 `await Bot.fetch_member(guild_id, user_id)` — cache-first guild member fetch; raises `discord.NotFound`
 
 `await Bot.fetch_user(user_id)` — inherited from `discord.Client`; cache-first
 
-`await Bot.set_status(status="online", *, activity=None, activity_type="playing")` — status: `"online" | "idle" | "dnd" | "invisible"`; activity_type: `"playing" | "watching" | "listening"`
+`await Bot.set_status(status="online", *, activity=None, activity_type="playing")` — status: `"online" | "idle" | "dnd" | "invisible"`; activity_type: `"playing" | "watching" | "listening" | "streaming"`
 
 `Bot.run(token, **kwargs)` — configures logging, starts the bot
 
@@ -64,6 +92,7 @@
 | `ctx.voice_channel` | `VoiceChannel \| StageChannel \| None` | Invoker's current voice channel |
 | `ctx.is_admin` | `bool` | `True` if invoker has administrator permission; `False` in DMs |
 | `ctx.data` | `dict \| None` | Raw interaction data |
+| `ctx.bot_permissions` | `discord.Permissions` | Bot's own permissions in the current channel; raises `RuntimeError` in DMs |
 
 ### Responding
 
@@ -117,6 +146,8 @@
 
 `ctx.get_member(user_id)` → `Member | None` — cache-only lookup
 
+`await ctx.fetch_member(user_id)` → `discord.Member` — API fetch; raises `RuntimeError` in DMs, `discord.NotFound` if not in guild
+
 ### Messages / Reactions / Threads / Channel
 
 `await ctx.purge(limit=10)` → `int` — bulk-delete; returns count
@@ -138,6 +169,10 @@
 `await ctx.lock_channel(*, reason=None)` / `await ctx.unlock_channel(*, reason=None)` — @everyone send_messages
 
 `ctx.fetch_bans(limit=100)` → `list[discord.BanEntry]`
+
+`ctx.typing()` → context manager — show typing indicator; use with `async with ctx.typing()`
+
+`await ctx.fetch_pinned_messages()` → `list[discord.Message]`
 
 ---
 
@@ -199,6 +234,8 @@ All factories return `MiddlewareFn = async (ctx, next) -> None`.
 | `admin_only(message)` | invoker lacks `administrator` permission | yes |
 | `allowed_roles(*role_ids, message)` | invoker holds none of the given role IDs | yes |
 | `channel_only(*channel_ids, message)` | channel not in the given set | yes |
+| `boost_only(message)` | invoker is not a server booster | yes |
+| `has_permission(*perms, message)` | invoker lacks any of the given permissions | yes |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,8 @@
 
 `Bot.use(middleware)` — register middleware (decorator or direct call); runs for slash commands only
 
+`@Bot.on_error` / `Bot.on_error(func)` — register a global error handler `async def handler(ctx, error)` called when any slash command raises an unhandled exception; overwrites any previously registered handler
+
 `Bot.add_plugin(plugin)` — load plugin; raises `TypeError` / `ValueError` on bad input or duplicate
 
 `await Bot.remove_plugin(plugin)` — unload plugin; removes commands, deregisters handlers, calls `on_unload()`
@@ -100,7 +102,7 @@ Middleware runs on component interactions exactly as it does for slash commands.
 
 `await ctx.defer(*, ephemeral=False)` — acknowledge without visible reply; use before slow operations
 
-`await ctx.send_embed(title, description=None, *, fields=None, footer=None, color=blue, ephemeral=False)` — fields: `[(name, value)]` or `[(name, value, inline)]`
+`await ctx.send_embed(title, description=None, *, fields=None, footer=None, thumbnail=None, image=None, author=None, timestamp=None, color=blue, ephemeral=False)` — fields: `[(name, value)]` or `[(name, value, inline)]`; `thumbnail`/`image`: URL strings; `author`: name string or `{"name", "icon_url", "url"}` dict; `timestamp=True` uses current UTC time
 
 `await ctx.send_file(path, *, filename=None, content=None, ephemeral=False)`
 
@@ -119,6 +121,8 @@ Middleware runs on component interactions exactly as it does for slash commands.
 `await ctx.choose(prompt, options, *, timeout=60, placeholder="Select an option", ephemeral=False)` → `str | None` — options: strings or `{"label", "value", "description"}` dicts
 
 `await ctx.paginate(pages, *, timeout=120, ephemeral=False)` — Prev/Next multi-page embed/text
+
+`await ctx.prompt(label, *, placeholder=None, max_length=None, timeout=660)` → `str | None` — single-field modal shortcut; returns submitted text or `None` on timeout/dismiss
 
 ### Moderation
 
@@ -287,3 +291,18 @@ Slash commands: `/rank` `/leaderboard` `/give_xp` `/set_rank` `/remove_rank` `/s
 `plugin.get_entry(guild_id, user_id)` → `{"xp": int, "level": int}`
 
 Storage: `<data_dir>/<guild_id>_xp.json`, `<data_dir>/<guild_id>_config.json`
+
+## `TagsPlugin` (`easycord.plugins.tags`)
+
+`TagsPlugin(*, data_dir="tags_data")`
+
+Per-guild text snippet store. All commands require a guild context.
+
+| Command | Args | Description |
+| --- | --- | --- |
+| `/tag get <name>` | name | Retrieve and display a tag |
+| `/tag set <name> <text>` | name, text | Create or overwrite a tag |
+| `/tag delete <name>` | name | Delete a tag (admin or original creator only) |
+| `/tag list` | — | List all tag names in this server |
+
+Storage: `tags_<guild_id>.json` in `data_dir`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,6 +188,74 @@ async def ping(ctx):
 bot.run(os.environ["DISCORD_TOKEN"])
 ```
 
+### Persistent button/select-menu handlers
+
+**discord.py** — manually intercept every interaction, check the type, parse the custom ID.
+
+```python
+@client.event
+async def on_interaction(interaction):
+    if interaction.type != discord.InteractionType.component:
+        return
+    cid = interaction.data.get("custom_id", "")
+    if cid.startswith("ban_"):
+        user_id = int(cid.removeprefix("ban_"))
+        member = await interaction.guild.fetch_member(user_id)
+        await member.ban()
+        await interaction.response.send_message("Banned.")
+```
+
+**EasyCord** — one decorator, suffix extracted automatically.
+
+```python
+@bot.component("ban_")
+async def ban_button(ctx, suffix: str):
+    member = await ctx.fetch_member(int(suffix))
+    await ctx.ban(member)
+    await ctx.respond("Banned.")
+```
+
+---
+
+### Permission-gated middleware
+
+**discord.py** — repeat the permission check inside every command.
+
+```python
+@tree.command()
+async def kick(interaction):
+    m = interaction.guild.get_member(interaction.user.id)
+    if not m or not m.guild_permissions.kick_members:
+        await interaction.response.send_message("Missing permission.", ephemeral=True)
+        return
+    ...
+```
+
+**EasyCord** — register once, applies to every command.
+
+```python
+bot.use(has_permission("kick_members"))
+```
+
+---
+
+### Webhook messages
+
+**discord.py** — create a webhook object, store it, call send separately.
+
+```python
+webhook = await channel.create_webhook(name="Bot")
+await webhook.send("Hello!", username="MyBot")
+```
+
+**EasyCord** — one call, webhook created and cached automatically.
+
+```python
+await bot.send_webhook(CHANNEL_ID, "Hello!", username="MyBot")
+```
+
+---
+
 ## Documentation map
 
 - [`getting-started.md`](getting-started.md): how to run, develop, and structure a bot

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -135,7 +135,13 @@ class _CommandsMixin:
                         )
                         return
                     _cooldown_last_used[uid] = now
-                await func(ctx, **kwargs)
+                try:
+                    await func(ctx, **kwargs)
+                except Exception as exc:
+                    if self._error_handler is not None:
+                        await self._error_handler(ctx, exc)
+                    else:
+                        raise
 
             await build_chain(ctx, invoke, self._middleware)()
 

--- a/easycord/_bot_events.py
+++ b/easycord/_bot_events.py
@@ -69,6 +69,24 @@ class _EventsMixin:
         self._middleware.append(middleware)
         return middleware
 
+    def on_error(self, func: Callable) -> Callable:
+        """Register a global error handler called when any slash command raises an unhandled exception.
+
+        Can be used as a decorator or called directly::
+
+            @bot.on_error
+            async def handle_error(ctx, error):
+                await ctx.respond(f"Something went wrong: {error}", ephemeral=True)
+
+        Only one handler can be registered. A second call overwrites the first.
+        """
+        if not callable(func):
+            raise TypeError(
+                f"error handler must be callable, got {type(func).__name__!r}"
+            )
+        self._error_handler = func
+        return func
+
     # ── User & member lookup ──────────────────────────────────
 
     async def fetch_member(self, guild_id: int, user_id: int) -> discord.Member:

--- a/easycord/_bot_events.py
+++ b/easycord/_bot_events.py
@@ -95,7 +95,7 @@ class _EventsMixin:
         status: Literal["online", "idle", "dnd", "invisible"] = "online",
         *,
         activity: str | None = None,
-        activity_type: Literal["playing", "watching", "listening"] = "playing",
+        activity_type: Literal["playing", "watching", "listening", "streaming"] = "playing",
     ) -> None:
         """Set the bot's presence status and optional activity text."""
         status_map = {
@@ -117,6 +117,80 @@ class _EventsMixin:
                 discord_activity = discord.Activity(
                     type=discord.ActivityType.listening, name=activity
                 )
+            elif activity_type == "streaming":
+                discord_activity = discord.Streaming(name=activity, url="")
             else:
                 discord_activity = discord.Game(activity)
         await self.change_presence(status=discord_status, activity=discord_activity)
+
+    # ── Component routing ─────────────────────────────────────
+
+    def component(self, id_or_func=None) -> Callable:
+        """Decorator that registers a persistent component (button / select-menu) handler.
+
+        The custom ID defaults to the function name when called without arguments::
+
+            @bot.component
+            async def confirm_ban(ctx):
+                await ctx.respond("Confirmed!")
+
+        Pass an explicit ID string to override::
+
+            @bot.component("confirm_ban")
+            async def handler(ctx):
+                await ctx.respond("Confirmed!")
+
+        For dynamic IDs, end the registered ID with ``_`` to enable prefix matching.
+        The suffix (everything after the prefix) is passed as the second argument::
+
+            @bot.component("ban_")
+            async def ban_button(ctx, suffix: str):
+                member = await ctx.guild.fetch_member(int(suffix))
+                await ctx.kick(member)
+        """
+        if callable(id_or_func):
+            self._component_handlers[id_or_func.__name__] = id_or_func  # type: ignore[attr-defined]
+            return id_or_func
+
+        custom_id: str = id_or_func  # type: ignore[assignment]
+
+        def decorator(func: Callable) -> Callable:
+            self._component_handlers[custom_id] = func  # type: ignore[attr-defined]
+            return func
+
+        return decorator
+
+    async def _dispatch_component(self, interaction: discord.Interaction) -> None:
+        """Route a component interaction to its registered handler."""
+        from .context import Context
+        from .middleware import build_chain
+
+        custom_id: str = (interaction.data or {}).get("custom_id", "")  # type: ignore[union-attr]
+
+        handler = self._component_handlers.get(custom_id)  # type: ignore[attr-defined]
+        suffix: str | None = None
+
+        if handler is None:
+            for registered_id, candidate in self._component_handlers.items():  # type: ignore[attr-defined]
+                if registered_id.endswith("_") and custom_id.startswith(registered_id):
+                    handler = candidate
+                    suffix = custom_id[len(registered_id):]
+                    break
+
+        if handler is None:
+            return
+
+        ctx = Context(interaction)
+
+        async def invoke() -> None:
+            if suffix is not None:
+                await handler(ctx, suffix)
+            else:
+                await handler(ctx)
+
+        await build_chain(ctx, invoke, self._middleware)()  # type: ignore[attr-defined]
+
+    async def on_interaction(self, interaction: discord.Interaction) -> None:
+        """Intercept component interactions and dispatch to registered handlers."""
+        if interaction.type == discord.InteractionType.component:
+            await self._dispatch_component(interaction)

--- a/easycord/_bot_guild.py
+++ b/easycord/_bot_guild.py
@@ -1,0 +1,175 @@
+"""Guild, channel, webhook, and emoji management helpers for Bot."""
+from __future__ import annotations
+
+import discord
+
+
+class _GuildMixin:
+    """Mixin: guild/channel/webhook/emoji management methods."""
+
+    # ── Guild lookup ──────────────────────────────────────────
+
+    async def fetch_guild(self, guild_id: int) -> discord.Guild:
+        """Return a guild by ID, checking the cache first.
+
+        Raises ``discord.NotFound`` if the bot is not in the guild.
+        """
+        return self.get_guild(guild_id) or await super().fetch_guild(guild_id)  # type: ignore[misc]
+
+    async def fetch_channel(self, channel_id: int) -> discord.abc.GuildChannel:
+        """Return a channel by ID, checking the cache first.
+
+        Raises ``discord.NotFound`` / ``discord.Forbidden`` on failure.
+        """
+        return self.get_channel(channel_id) or await super().fetch_channel(channel_id)  # type: ignore[misc]
+
+    # ── Guild management ──────────────────────────────────────
+
+    async def leave_guild(self, guild_id: int) -> None:
+        """Make the bot leave a guild.
+
+        Raises ``RuntimeError`` if the bot is not in the guild.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None:
+            raise RuntimeError(f"Bot is not in guild {guild_id}")
+        await guild.leave()
+
+    # ── Channel management ────────────────────────────────────
+
+    async def create_channel(
+        self,
+        guild_id: int,
+        name: str,
+        *,
+        channel_type: str = "text",
+        category_id: int | None = None,
+        topic: str | None = None,
+        reason: str | None = None,
+    ) -> discord.abc.GuildChannel:
+        """Create a channel in a guild and return it.
+
+        ``channel_type`` must be one of ``"text"``, ``"voice"``, ``"category"``,
+        ``"stage"``, or ``"forum"``.
+
+        Raises ``RuntimeError`` if the bot is not in the guild.
+        Raises ``ValueError`` for an unrecognised ``channel_type``.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None:
+            raise RuntimeError(f"Bot is not in guild {guild_id}")
+
+        category: discord.CategoryChannel | None = None
+        if category_id is not None:
+            cat = self.get_channel(category_id)
+            if isinstance(cat, discord.CategoryChannel):
+                category = cat
+
+        if channel_type == "text":
+            return await guild.create_text_channel(
+                name, category=category, topic=topic, reason=reason
+            )
+        if channel_type == "voice":
+            return await guild.create_voice_channel(
+                name, category=category, reason=reason
+            )
+        if channel_type == "category":
+            return await guild.create_category(name, reason=reason)
+        if channel_type == "stage":
+            return await guild.create_stage_channel(
+                name, category=category, reason=reason
+            )
+        if channel_type == "forum":
+            return await guild.create_forum(
+                name, category=category, reason=reason
+            )
+        raise ValueError(
+            f"Unknown channel_type {channel_type!r}. "
+            "Must be 'text', 'voice', 'category', 'stage', or 'forum'."
+        )
+
+    async def delete_channel(
+        self, channel_id: int, *, reason: str | None = None
+    ) -> None:
+        """Delete a channel by ID."""
+        channel = self.get_channel(channel_id) or await super().fetch_channel(channel_id)  # type: ignore[misc]
+        await channel.delete(reason=reason)
+
+    # ── Webhooks ──────────────────────────────────────────────
+
+    async def send_webhook(
+        self,
+        channel_id: int,
+        content: str | None = None,
+        *,
+        username: str | None = None,
+        avatar_url: str | None = None,
+        embed: discord.Embed | None = None,
+        **kwargs,
+    ) -> None:
+        """Send a message via a webhook in the given channel.
+
+        On first call for a channel, creates a webhook named ``"EasyCord"`` and
+        caches it. Subsequent calls reuse the cached webhook.
+
+        Example::
+
+            await bot.send_webhook(CHANNEL_ID, "Hello from a webhook!")
+        """
+        if channel_id not in self._webhooks:  # type: ignore[attr-defined]
+            channel = self.get_channel(channel_id)
+            if not isinstance(channel, discord.TextChannel):
+                raise RuntimeError(
+                    f"Channel {channel_id} is not a text channel or was not found in cache"
+                )
+            self._webhooks[channel_id] = await channel.create_webhook(name="EasyCord")  # type: ignore[attr-defined]
+        webhook = self._webhooks[channel_id]  # type: ignore[attr-defined]
+        await webhook.send(content, username=username, avatar_url=avatar_url, embed=embed, **kwargs)
+
+    # ── Emoji management ──────────────────────────────────────
+
+    async def create_emoji(
+        self,
+        guild_id: int,
+        name: str,
+        image_path: str,
+        *,
+        reason: str | None = None,
+    ) -> discord.Emoji:
+        """Create a custom emoji in a guild from a local image file.
+
+        Raises ``RuntimeError`` if the bot is not in the guild.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None:
+            raise RuntimeError(f"Bot is not in guild {guild_id}")
+        with open(image_path, "rb") as f:
+            image_bytes = f.read()
+        return await guild.create_custom_emoji(name=name, image=image_bytes, reason=reason)
+
+    async def delete_emoji(
+        self,
+        guild_id: int,
+        emoji_id: int,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        """Delete a custom emoji from a guild by emoji ID.
+
+        Raises ``RuntimeError`` if the bot is not in the guild.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None:
+            raise RuntimeError(f"Bot is not in guild {guild_id}")
+        emoji = await guild.fetch_emoji(emoji_id)
+        await emoji.delete(reason=reason)
+
+    async def fetch_guild_emojis(self, guild_id: int) -> list[discord.Emoji]:
+        """Return all custom emojis for a guild.
+
+        Raises ``RuntimeError`` if the bot is not in the guild.
+        """
+        guild = self.get_guild(guild_id)
+        if guild is None:
+            raise RuntimeError(f"Bot is not in guild {guild_id}")
+        return await guild.fetch_emojis()

--- a/easycord/_context_base.py
+++ b/easycord/_context_base.py
@@ -104,6 +104,10 @@ class BaseContext:
         *,
         fields: list[tuple] | None = None,
         footer: str | None = None,
+        thumbnail: str | None = None,
+        image: str | None = None,
+        author: str | dict | None = None,
+        timestamp=None,
         color: discord.Color = discord.Color.blue(),
         ephemeral: bool = False,
         **kwargs,
@@ -112,13 +116,39 @@ class BaseContext:
 
         ``fields`` is a list of ``(name, value)`` or ``(name, value, inline)``
         tuples. ``inline`` defaults to ``True`` when omitted.
+
+        ``thumbnail`` and ``image`` accept a URL string.
+
+        ``author`` accepts a name string or a dict with ``name``, ``icon_url``,
+        and ``url`` keys.
+
+        ``timestamp=True`` uses the current UTC time; pass a ``datetime`` for a
+        specific timestamp.
         """
-        embed = discord.Embed(title=title, description=description, color=color)
+        ts = None
+        if timestamp is True:
+            ts = discord.utils.utcnow()
+        elif timestamp:
+            ts = timestamp
+
+        embed = discord.Embed(
+            title=title, description=description, color=color,
+            **({"timestamp": ts} if ts is not None else {}),
+        )
         for field in (fields or []):
             name, value, *rest = field
             embed.add_field(name=name, value=value, inline=rest[0] if rest else True)
         if footer:
             embed.set_footer(text=footer)
+        if thumbnail:
+            embed.set_thumbnail(url=thumbnail)
+        if image:
+            embed.set_image(url=image)
+        if author is not None:
+            if isinstance(author, str):
+                embed.set_author(name=author)
+            else:
+                embed.set_author(**author)
         await self.respond(embed=embed, ephemeral=ephemeral, **kwargs)
 
     async def dm(

--- a/easycord/_context_base.py
+++ b/easycord/_context_base.py
@@ -221,3 +221,26 @@ class BaseContext:
         Returns ``None`` if the member is not cached or the command was run in a DM.
         """
         return self.guild.get_member(user_id) if self.guild else None
+
+    async def fetch_member(self, user_id: int) -> discord.Member:
+        """Fetch a guild member by user ID.
+
+        Tries the guild cache first; falls back to an API call.
+        Raises ``RuntimeError`` if called outside a guild.
+        Raises ``discord.NotFound`` if the user is not in the guild.
+        """
+        if self.guild is None:
+            raise RuntimeError("fetch_member requires a guild context")
+        return await self.guild.fetch_member(user_id)
+
+    @property
+    def bot_permissions(self) -> discord.Permissions:
+        """The bot's own permissions in the current channel.
+
+        Returns ``channel.permissions_for(guild.me)`` — useful for checking
+        whether the bot can attach files, embed links, manage messages, etc.
+        Raises ``RuntimeError`` outside a guild.
+        """
+        if self.guild is None:
+            raise RuntimeError("bot_permissions requires a guild context")
+        return self.channel.permissions_for(self.guild.me)  # type: ignore[union-attr]

--- a/easycord/_context_channels.py
+++ b/easycord/_context_channels.py
@@ -113,3 +113,24 @@ class ChannelMixin:
         The channel must be a ``discord.TextChannel`` with the ``news`` type.
         """
         await message.publish()
+
+    # ── Typing indicator ──────────────────────────────────────────────────────
+
+    def typing(self):
+        """Return a context manager that shows the typing indicator in the current channel.
+
+        Use with ``async with``::
+
+            async with ctx.typing():
+                data = await fetch_data()
+                await ctx.respond(data)
+        """
+        if self.channel is None:  # type: ignore[attr-defined]
+            raise RuntimeError("typing requires a channel context")
+        return self.channel.typing()  # type: ignore[attr-defined]
+
+    async def fetch_pinned_messages(self) -> list[discord.Message]:
+        """Return all pinned messages in the current channel."""
+        if self.channel is None:  # type: ignore[attr-defined]
+            raise RuntimeError("fetch_pinned_messages requires a channel context")
+        return await self.channel.pins()  # type: ignore[attr-defined]

--- a/easycord/_context_ui.py
+++ b/easycord/_context_ui.py
@@ -233,3 +233,27 @@ class UIMixin:
         view = _ChooseView(timeout=timeout)
         await self.respond(prompt, ephemeral=ephemeral, view=view)  # type: ignore[attr-defined]
         return await future
+
+    async def prompt(
+        self,
+        label: str,
+        *,
+        placeholder: str | None = None,
+        max_length: int | None = None,
+        timeout: float = 660,
+    ) -> str | None:
+        """Show a single-field modal and return the submitted text, or ``None`` on timeout.
+
+        Shortcut for :meth:`ask_form` when only one text input is needed::
+
+            text = await ctx.prompt("What's your reason?", placeholder="Enter reason…")
+            if text:
+                await ctx.respond(f"Reason: {text}")
+        """
+        field: dict = {"label": label}
+        if placeholder is not None:
+            field["placeholder"] = placeholder
+        if max_length is not None:
+            field["max_length"] = max_length
+        result = await self.ask_form(label, value=field)  # type: ignore[attr-defined]
+        return result["value"] if result else None

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -12,12 +12,13 @@ from .middleware import MiddlewareFn
 from .plugin import Plugin
 from ._bot_commands import _CommandsMixin
 from ._bot_events import _EventsMixin
+from ._bot_guild import _GuildMixin
 from ._bot_plugins import _PluginsMixin
 
 logger = logging.getLogger("easycord")
 
 
-class Bot(_EventsMixin, _PluginsMixin, _CommandsMixin, discord.Client):
+class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Client):
     """
     The main EasyCord bot — a discord.Client with slash commands,
     middleware, event listeners, and plugins built in.
@@ -61,6 +62,8 @@ class Bot(_EventsMixin, _PluginsMixin, _CommandsMixin, discord.Client):
         self._event_handlers: dict[str, list[Callable]] = {}
         self._plugins: list[Plugin] = []
         self._task_handles: dict[int, list[asyncio.Task]] = {}
+        self._webhooks: dict[int, discord.Webhook] = {}
+        self._component_handlers: dict[str, Callable] = {}
 
     async def setup_hook(self) -> None:
         if self._auto_sync:

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -64,6 +64,7 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
         self._task_handles: dict[int, list[asyncio.Task]] = {}
         self._webhooks: dict[int, discord.Webhook] = {}
         self._component_handlers: dict[str, Callable] = {}
+        self._error_handler = None
 
     async def setup_hook(self) -> None:
         if self._auto_sync:

--- a/easycord/middleware.py
+++ b/easycord/middleware.py
@@ -194,6 +194,74 @@ def rate_limit(
     return handler
 
 
+def boost_only(
+    message: str = "This command is for server boosters only.",
+) -> MiddlewareFn:
+    """Block commands unless the invoking member is currently boosting the server.
+
+    Silently passes in DMs. Combine with ``guild_only()`` if the command must
+    be server-only.
+
+    Example::
+
+        bot.use(boost_only())
+    """
+
+    async def handler(ctx: Context, proceed: Callable[[], Awaitable[None]]) -> None:
+        if ctx.guild is None:
+            await proceed()
+            return
+        member = ctx.guild.get_member(ctx.user.id)
+        if member is None or member.premium_since is None:
+            await ctx.respond(message, ephemeral=True)
+            return
+        await proceed()
+
+    return handler
+
+
+def has_permission(
+    *permissions: str,
+    message: str | None = None,
+) -> MiddlewareFn:
+    """Block commands unless the invoking member holds all of the given permissions.
+
+    ``permissions`` are ``discord.Permissions`` attribute names
+    (e.g. ``"kick_members"``, ``"manage_messages"``).
+
+    Silently passes in DMs. Combine with ``guild_only()`` if the command must
+    be server-only.
+
+    Example::
+
+        bot.use(has_permission("kick_members", "ban_members"))
+    """
+
+    async def handler(ctx: Context, proceed: Callable[[], Awaitable[None]]) -> None:
+        if ctx.guild is None:
+            await proceed()
+            return
+        member = ctx.guild.get_member(ctx.user.id)
+        if member is None:
+            await ctx.respond(
+                message or "Could not verify your permissions.", ephemeral=True
+            )
+            return
+        missing = [
+            p for p in permissions
+            if not getattr(member.guild_permissions, p, False)
+        ]
+        if missing:
+            await ctx.respond(
+                message or f"You need the following permission(s): {', '.join(missing)}.",
+                ephemeral=True,
+            )
+            return
+        await proceed()
+
+    return handler
+
+
 def catch_errors(
     message: str = "Something went wrong. Please try again.",
 ) -> MiddlewareFn:

--- a/easycord/plugins/__init__.py
+++ b/easycord/plugins/__init__.py
@@ -1,6 +1,7 @@
 """Optional first-party EasyCord plugins."""
 from .levels import LevelsPlugin
 from .polls import PollsPlugin
+from .tags import TagsPlugin
 from .welcome import WelcomePlugin
 
-__all__ = ["LevelsPlugin", "PollsPlugin", "WelcomePlugin"]
+__all__ = ["LevelsPlugin", "PollsPlugin", "TagsPlugin", "WelcomePlugin"]

--- a/easycord/plugins/tags.py
+++ b/easycord/plugins/tags.py
@@ -1,0 +1,97 @@
+"""Per-guild text snippet storage and slash commands."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import discord
+
+from easycord.decorators import slash
+from easycord.plugin import Plugin
+
+
+class TagsStore:
+    """Handles atomic per-guild tag JSON storage."""
+
+    def __init__(self, data_dir: str) -> None:
+        self._data_dir = Path(data_dir)
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, guild_id: int) -> Path:
+        return self._data_dir / f"tags_{guild_id}.json"
+
+    def _load(self, guild_id: int) -> dict[str, dict]:
+        path = self._path(guild_id)
+        if not path.exists():
+            return {}
+        with path.open() as f:
+            return json.load(f)
+
+    def _save(self, guild_id: int, data: dict[str, dict]) -> None:
+        path = self._path(guild_id)
+        tmp = path.with_suffix(".tmp")
+        with tmp.open("w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+
+    def get(self, guild_id: int, name: str) -> dict | None:
+        return self._load(guild_id).get(name)
+
+    def set(self, guild_id: int, name: str, text: str, *, author_id: int) -> None:
+        data = self._load(guild_id)
+        data[name] = {"text": text, "author_id": author_id}
+        self._save(guild_id, data)
+
+    def delete(self, guild_id: int, name: str) -> None:
+        data = self._load(guild_id)
+        if name in data:
+            del data[name]
+            self._save(guild_id, data)
+
+    def list_names(self, guild_id: int) -> list[str]:
+        return sorted(self._load(guild_id).keys())
+
+
+class TagsPlugin(Plugin):
+    """Slash-command tag store. Adds ``/tag get``, ``/tag set``, ``/tag delete``, ``/tag list``."""
+
+    def __init__(self, *, data_dir: str = "tags_data") -> None:
+        self._store = TagsStore(data_dir)
+
+    @slash(description="Retrieve a tag by name.", guild_only=True)
+    async def get(self, ctx, name: str) -> None:
+        entry = self._store.get(ctx.guild_id, name)
+        if entry is None:
+            await ctx.respond(f"Tag `{name}` not found.", ephemeral=True)
+            return
+        await ctx.respond(entry["text"])
+
+    @slash(description="Create or update a tag.", guild_only=True)
+    async def set(self, ctx, name: str, text: str) -> None:
+        self._store.set(ctx.guild_id, name, text, author_id=ctx.user.id)
+        await ctx.respond(f"Tag `{name}` saved.", ephemeral=True)
+
+    @slash(description="Delete a tag (admin or creator only).", guild_only=True)
+    async def delete(self, ctx, name: str) -> None:
+        entry = self._store.get(ctx.guild_id, name)
+        if entry is None:
+            await ctx.respond(f"Tag `{name}` not found.", ephemeral=True)
+            return
+        member = ctx.guild.get_member(ctx.user.id)
+        is_admin = member is not None and member.guild_permissions.administrator
+        if ctx.user.id != entry["author_id"] and not is_admin:
+            await ctx.respond(
+                "You can only delete your own tags (or be an admin).", ephemeral=True
+            )
+            return
+        self._store.delete(ctx.guild_id, name)
+        await ctx.respond(f"Tag `{name}` deleted.", ephemeral=True)
+
+    @slash(description="List all tags in this server.", guild_only=True)
+    async def list(self, ctx) -> None:
+        names = self._store.list_names(ctx.guild_id)
+        if not names:
+            await ctx.respond("No tags yet.", ephemeral=True)
+            return
+        await ctx.respond("**Tags:**\n" + "\n".join(names), ephemeral=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "easycord"
-version = "2.5"
+version = "2.7"
 description = "Decorator-first Discord bot framework — slash commands, permissions, cooldowns, embeds, and per-guild config in a fraction of the discord.py code"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -716,3 +716,47 @@ async def test_fetch_guild_emojis(bot):
     bot.get_guild = MagicMock(return_value=guild)
     result = await bot.fetch_guild_emojis(123)
     assert result == [e1, e2]
+
+
+# ── @bot.on_error ─────────────────────────────────────────────────────────────
+
+async def test_on_error_registers_handler(bot):
+    async def handler(ctx, error):
+        pass
+    bot.on_error(handler)
+    assert bot._error_handler is handler
+
+
+async def test_on_error_as_decorator(bot):
+    @bot.on_error
+    async def handler(ctx, error):
+        pass
+    assert bot._error_handler is handler
+
+
+async def test_on_error_called_on_command_exception(bot):
+    errors_seen = []
+
+    @bot.on_error
+    async def handler(ctx, error):
+        errors_seen.append(error)
+
+    boom = ValueError("boom")
+
+    @bot.slash(description="test")
+    async def bad_cmd(ctx):
+        raise boom
+
+    cmd_obj = bot.tree.add_command.call_args_list[-1][0][0]
+    mock_interaction = MagicMock()
+    mock_interaction.response.send_message = AsyncMock()
+    mock_interaction.response.defer = AsyncMock()
+    mock_interaction.followup.send = AsyncMock()
+    mock_interaction.command = MagicMock()
+    mock_interaction.command.name = "bad_cmd"
+    mock_interaction.guild = None
+    mock_interaction.user = MagicMock()
+    mock_interaction.channel = MagicMock()
+    mock_interaction.client = MagicMock()
+    await cmd_obj.callback(mock_interaction)
+    assert errors_seen == [boom]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -561,3 +561,158 @@ async def test_remove_plugin_cancels_tasks(bot):
     assert id(plugin) in bot._task_handles
     await bot.remove_plugin(plugin)
     assert id(plugin) not in bot._task_handles
+
+
+# ── set_status streaming ──────────────────────────────────────────────────────
+
+async def test_set_status_streaming(bot):
+    bot.change_presence = AsyncMock()
+    await bot.set_status("online", activity="live now", activity_type="streaming")
+    call_kwargs = bot.change_presence.call_args.kwargs
+    activity = call_kwargs["activity"]
+    assert isinstance(activity, discord.Streaming)
+    assert activity.name == "live now"
+
+
+# ── _GuildMixin ───────────────────────────────────────────────────────────────
+
+async def test_fetch_guild_returns_cached(bot):
+    guild = MagicMock(spec=discord.Guild)
+    bot.get_guild = MagicMock(return_value=guild)
+    result = await bot.fetch_guild(123)
+    assert result is guild
+    bot.get_guild.assert_called_once_with(123)
+
+
+async def test_fetch_channel_returns_cached(bot):
+    channel = MagicMock(spec=discord.TextChannel)
+    bot.get_channel = MagicMock(return_value=channel)
+    result = await bot.fetch_channel(456)
+    assert result is channel
+
+
+async def test_fetch_channel_falls_back_to_api(bot):
+    channel = MagicMock(spec=discord.TextChannel)
+    bot.get_channel = MagicMock(return_value=None)
+    with patch.object(discord.Client, "fetch_channel", new=AsyncMock(return_value=channel)):
+        result = await bot.fetch_channel(456)
+    assert result is channel
+
+
+async def test_leave_guild_calls_guild_leave(bot):
+    guild = MagicMock(spec=discord.Guild)
+    guild.leave = AsyncMock()
+    bot.get_guild = MagicMock(return_value=guild)
+    await bot.leave_guild(123)
+    guild.leave.assert_called_once()
+
+
+async def test_leave_guild_raises_when_not_in_guild(bot):
+    bot.get_guild = MagicMock(return_value=None)
+    with pytest.raises(RuntimeError, match="not in guild"):
+        await bot.leave_guild(999)
+
+
+async def test_create_channel_text(bot):
+    guild = MagicMock(spec=discord.Guild)
+    channel = MagicMock(spec=discord.TextChannel)
+    guild.create_text_channel = AsyncMock(return_value=channel)
+    bot.get_guild = MagicMock(return_value=guild)
+    result = await bot.create_channel(123, "general")
+    assert result is channel
+    guild.create_text_channel.assert_called_once_with(
+        "general", category=None, topic=None, reason=None
+    )
+
+
+async def test_create_channel_voice(bot):
+    guild = MagicMock(spec=discord.Guild)
+    channel = MagicMock(spec=discord.VoiceChannel)
+    guild.create_voice_channel = AsyncMock(return_value=channel)
+    bot.get_guild = MagicMock(return_value=guild)
+    result = await bot.create_channel(123, "voice-chat", channel_type="voice")
+    assert result is channel
+
+
+async def test_create_channel_invalid_type_raises(bot):
+    guild = MagicMock(spec=discord.Guild)
+    bot.get_guild = MagicMock(return_value=guild)
+    with pytest.raises(ValueError, match="Unknown channel_type"):
+        await bot.create_channel(123, "x", channel_type="invalid")
+
+
+async def test_create_channel_raises_when_guild_not_found(bot):
+    bot.get_guild = MagicMock(return_value=None)
+    with pytest.raises(RuntimeError, match="not in guild"):
+        await bot.create_channel(999, "test")
+
+
+async def test_delete_channel(bot):
+    channel = MagicMock()
+    channel.delete = AsyncMock()
+    bot.get_channel = MagicMock(return_value=channel)
+    await bot.delete_channel(456)
+    channel.delete.assert_called_once_with(reason=None)
+
+
+async def test_delete_channel_fetches_when_not_cached(bot):
+    channel = MagicMock()
+    channel.delete = AsyncMock()
+    bot.get_channel = MagicMock(return_value=None)
+    with patch.object(discord.Client, "fetch_channel", new=AsyncMock(return_value=channel)):
+        await bot.delete_channel(456, reason="cleanup")
+    channel.delete.assert_called_once_with(reason="cleanup")
+
+
+async def test_send_webhook_creates_and_sends(bot):
+    channel = MagicMock(spec=discord.TextChannel)
+    webhook = MagicMock(spec=discord.Webhook)
+    webhook.send = AsyncMock()
+    channel.create_webhook = AsyncMock(return_value=webhook)
+    bot.get_channel = MagicMock(return_value=channel)
+    await bot.send_webhook(111, "hello")
+    channel.create_webhook.assert_called_once_with(name="EasyCord")
+    webhook.send.assert_called_once_with("hello", username=None, avatar_url=None, embed=None)
+
+
+async def test_send_webhook_reuses_cached_webhook(bot):
+    webhook = MagicMock(spec=discord.Webhook)
+    webhook.send = AsyncMock()
+    bot._webhooks[111] = webhook
+    await bot.send_webhook(111, "hello again")
+    webhook.send.assert_called_once()
+
+
+async def test_create_emoji(bot):
+    guild = MagicMock(spec=discord.Guild)
+    emoji = MagicMock(spec=discord.Emoji)
+    guild.create_custom_emoji = AsyncMock(return_value=emoji)
+    bot.get_guild = MagicMock(return_value=guild)
+    with patch("builtins.open", MagicMock(return_value=MagicMock(
+        __enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"imgdata"))),
+        __exit__=MagicMock(return_value=False),
+    ))):
+        result = await bot.create_emoji(123, "cool", "cool.png")
+    assert result is emoji
+    guild.create_custom_emoji.assert_called_once_with(name="cool", image=b"imgdata", reason=None)
+
+
+async def test_delete_emoji(bot):
+    guild = MagicMock(spec=discord.Guild)
+    emoji = MagicMock(spec=discord.Emoji)
+    emoji.delete = AsyncMock()
+    guild.fetch_emoji = AsyncMock(return_value=emoji)
+    bot.get_guild = MagicMock(return_value=guild)
+    await bot.delete_emoji(123, 999)
+    guild.fetch_emoji.assert_called_once_with(999)
+    emoji.delete.assert_called_once_with(reason=None)
+
+
+async def test_fetch_guild_emojis(bot):
+    guild = MagicMock(spec=discord.Guild)
+    e1 = MagicMock(spec=discord.Emoji)
+    e2 = MagicMock(spec=discord.Emoji)
+    guild.fetch_emojis = AsyncMock(return_value=[e1, e2])
+    bot.get_guild = MagicMock(return_value=guild)
+    result = await bot.fetch_guild_emojis(123)
+    assert result == [e1, e2]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,173 @@
+"""Tests for @bot.component persistent component routing."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+
+from easycord import Bot
+from discord import app_commands
+
+
+@pytest.fixture
+def bot():
+    mock_tree = MagicMock()
+    mock_tree.add_command = MagicMock()
+    mock_tree.remove_command = MagicMock()
+    mock_tree.sync = AsyncMock()
+
+    with patch("discord.Client.__init__", return_value=None), \
+         patch("easycord.bot.app_commands.CommandTree", return_value=mock_tree):
+        b = Bot(intents=MagicMock(), auto_sync=False)
+        b.is_ready = MagicMock(return_value=False)
+        return b
+
+
+def _make_component_interaction(custom_id: str):
+    interaction = MagicMock()
+    interaction.type = discord.InteractionType.component
+    interaction.data = {"custom_id": custom_id}
+    interaction.response.send_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.guild = MagicMock()
+    interaction.user = MagicMock()
+    interaction.command = None
+    return interaction
+
+
+# ── decorator API ─────────────────────────────────────────────────────────────
+
+def test_component_registers_with_explicit_id(bot):
+    @bot.component("my_button")
+    async def handler(ctx):
+        pass
+    assert "my_button" in bot._component_handlers
+
+
+def test_component_defaults_id_to_function_name(bot):
+    @bot.component
+    async def confirm_action(ctx):
+        pass
+    assert "confirm_action" in bot._component_handlers
+
+
+def test_component_returns_original_function(bot):
+    async def handler(ctx):
+        pass
+    result = bot.component("btn")(handler)
+    assert result is handler
+
+
+# ── exact match routing ───────────────────────────────────────────────────────
+
+async def test_component_exact_match_invokes_handler(bot):
+    called = []
+
+    @bot.component("yes_btn")
+    async def yes_handler(ctx):
+        called.append(True)
+
+    interaction = _make_component_interaction("yes_btn")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert called == [True]
+
+
+async def test_component_unmatched_is_silently_ignored(bot):
+    called = []
+
+    @bot.component("yes_btn")
+    async def yes_handler(ctx):
+        called.append(True)
+
+    interaction = _make_component_interaction("no_btn")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert called == []
+
+
+async def test_component_non_component_interaction_is_ignored(bot):
+    called = []
+
+    @bot.component("yes_btn")
+    async def yes_handler(ctx):
+        called.append(True)
+
+    interaction = _make_component_interaction("yes_btn")
+    interaction.type = discord.InteractionType.application_command
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert called == []
+
+
+# ── prefix routing ────────────────────────────────────────────────────────────
+
+async def test_component_prefix_match_invokes_handler_with_suffix(bot):
+    received = []
+
+    @bot.component("ban_")
+    async def ban_handler(ctx, suffix: str):
+        received.append(suffix)
+
+    interaction = _make_component_interaction("ban_12345")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert received == ["12345"]
+
+
+async def test_component_exact_wins_over_prefix(bot):
+    order = []
+
+    @bot.component("ban_exact")
+    async def exact_handler(ctx):
+        order.append("exact")
+
+    @bot.component("ban_")
+    async def prefix_handler(ctx, suffix: str):
+        order.append(f"prefix:{suffix}")
+
+    interaction = _make_component_interaction("ban_exact")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert order == ["exact"]
+
+
+async def test_component_prefix_no_match_is_ignored(bot):
+    called = []
+
+    @bot.component("ban_")
+    async def handler(ctx, suffix: str):
+        called.append(suffix)
+
+    interaction = _make_component_interaction("kick_99")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert called == []
+
+
+# ── middleware ────────────────────────────────────────────────────────────────
+
+async def test_component_runs_middleware(bot):
+    order = []
+
+    async def mw(ctx, proceed):
+        order.append("before")
+        await proceed()
+        order.append("after")
+
+    bot.use(mw)
+
+    @bot.component("the_btn")
+    async def handler(ctx):
+        order.append("handler")
+
+    interaction = _make_component_interaction("the_btn")
+    with patch.object(discord.Client, "dispatch"):
+        await bot.on_interaction(interaction)
+
+    assert order == ["before", "handler", "after"]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -500,3 +500,110 @@ async def test_fetch_pinned_messages_raises_when_no_channel(ctx, interaction):
     interaction.channel = None
     with pytest.raises(RuntimeError, match="channel"):
         await ctx.fetch_pinned_messages()
+
+
+# ── ctx.prompt() ──────────────────────────────────────────────────────────────
+
+async def test_prompt_returns_text(ctx):
+    ctx.ask_form = AsyncMock(return_value={"value": "hello there"})
+    result = await ctx.prompt("Enter something")
+    assert result == "hello there"
+
+
+async def test_prompt_returns_none_on_timeout(ctx):
+    ctx.ask_form = AsyncMock(return_value=None)
+    result = await ctx.prompt("Enter something")
+    assert result is None
+
+
+async def test_prompt_passes_placeholder(ctx):
+    ctx.ask_form = AsyncMock(return_value={"value": "x"})
+    await ctx.prompt("Label", placeholder="hint text")
+    call_kwargs = ctx.ask_form.call_args
+    assert call_kwargs[1]["value"]["placeholder"] == "hint text"
+
+
+async def test_prompt_passes_max_length(ctx):
+    ctx.ask_form = AsyncMock(return_value={"value": "x"})
+    await ctx.prompt("Label", max_length=50)
+    call_kwargs = ctx.ask_form.call_args
+    assert call_kwargs[1]["value"]["max_length"] == 50
+
+
+# ── send_embed extras ─────────────────────────────────────────────────────────
+
+async def test_send_embed_thumbnail(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed:
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        instance.set_thumbnail = MagicMock()
+        await ctx.send_embed("Title", thumbnail="https://example.com/thumb.png")
+    instance.set_thumbnail.assert_called_once_with(url="https://example.com/thumb.png")
+
+
+async def test_send_embed_image(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed:
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        instance.set_image = MagicMock()
+        await ctx.send_embed("Title", image="https://example.com/img.png")
+    instance.set_image.assert_called_once_with(url="https://example.com/img.png")
+
+
+async def test_send_embed_author_string(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed:
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        instance.set_author = MagicMock()
+        await ctx.send_embed("Title", author="Bot Name")
+    instance.set_author.assert_called_once_with(name="Bot Name")
+
+
+async def test_send_embed_author_dict(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed:
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        instance.set_author = MagicMock()
+        await ctx.send_embed("Title", author={"name": "Bot", "icon_url": "https://icon.png", "url": "https://bot.dev"})
+    instance.set_author.assert_called_once_with(name="Bot", icon_url="https://icon.png", url="https://bot.dev")
+
+
+async def test_send_embed_timestamp_true(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed, patch("discord.utils.utcnow") as mock_now:
+        fake_now = MagicMock()
+        mock_now.return_value = fake_now
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        await ctx.send_embed("Title", timestamp=True)
+    assert MockEmbed.call_args.kwargs.get("timestamp") == fake_now
+
+
+async def test_send_embed_no_extras_unchanged(ctx):
+    from unittest.mock import patch
+    ctx.interaction.response.send_message = AsyncMock()
+    with patch("discord.Embed") as MockEmbed:
+        instance = MockEmbed.return_value
+        instance.add_field = MagicMock()
+        instance.set_footer = MagicMock()
+        instance.set_thumbnail = MagicMock()
+        instance.set_image = MagicMock()
+        instance.set_author = MagicMock()
+        await ctx.send_embed("Title", "Desc")
+    instance.set_thumbnail.assert_not_called()
+    instance.set_image.assert_not_called()
+    instance.set_author.assert_not_called()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -433,3 +433,70 @@ async def test_move_member_disconnects_on_none(ctx, interaction):
     member.edit = AsyncMock()
     await ctx.move_member(member, None)
     member.edit.assert_called_once_with(voice_channel=None, reason=None)
+
+
+# ── fetch_member ──────────────────────────────────────────────────────────────
+
+async def test_fetch_member_returns_member(ctx, interaction):
+    member = MagicMock(spec=discord.Member)
+    interaction.guild.fetch_member = AsyncMock(return_value=member)
+    result = await ctx.fetch_member(42)
+    assert result is member
+    interaction.guild.fetch_member.assert_called_once_with(42)
+
+
+async def test_fetch_member_raises_outside_guild(ctx, interaction):
+    interaction.guild = None
+    with pytest.raises(RuntimeError, match="guild context"):
+        await ctx.fetch_member(42)
+
+
+# ── bot_permissions ───────────────────────────────────────────────────────────
+
+def test_bot_permissions_returns_permissions(ctx, interaction):
+    perms = MagicMock(spec=discord.Permissions)
+    me = MagicMock()
+    interaction.guild.me = me
+    interaction.channel.permissions_for = MagicMock(return_value=perms)
+    result = ctx.bot_permissions
+    assert result is perms
+    interaction.channel.permissions_for.assert_called_once_with(me)
+
+
+def test_bot_permissions_raises_outside_guild(ctx, interaction):
+    interaction.guild = None
+    with pytest.raises(RuntimeError, match="guild context"):
+        _ = ctx.bot_permissions
+
+
+# ── typing ────────────────────────────────────────────────────────────────────
+
+def test_typing_delegates_to_channel(ctx, interaction):
+    typing_cm = MagicMock()
+    interaction.channel.typing = MagicMock(return_value=typing_cm)
+    result = ctx.typing()
+    assert result is typing_cm
+    interaction.channel.typing.assert_called_once()
+
+
+def test_typing_raises_when_no_channel(ctx, interaction):
+    interaction.channel = None
+    with pytest.raises(RuntimeError, match="channel"):
+        ctx.typing()
+
+
+# ── fetch_pinned_messages ─────────────────────────────────────────────────────
+
+async def test_fetch_pinned_messages_returns_list(ctx, interaction):
+    msg1 = MagicMock(spec=discord.Message)
+    msg2 = MagicMock(spec=discord.Message)
+    interaction.channel.pins = AsyncMock(return_value=[msg1, msg2])
+    result = await ctx.fetch_pinned_messages()
+    assert result == [msg1, msg2]
+    interaction.channel.pins.assert_called_once()
+
+
+async def test_fetch_pinned_messages_raises_when_no_channel(ctx, interaction):
+    interaction.channel = None
+    with pytest.raises(RuntimeError, match="channel"):
+        await ctx.fetch_pinned_messages()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -340,3 +340,107 @@ async def test_channel_only_custom_message():
     proceed = AsyncMock()
     await channel_only(42, message="Wrong channel!")(ctx, proceed)
     assert "Wrong channel!" in ctx.respond.call_args[0][0]
+
+
+# ── boost_only / has_permission ───────────────────────────────────────────────
+
+from easycord.middleware import boost_only, has_permission
+import datetime
+
+
+def _mw_make_ctx_boost(*, guild=True, is_booster=True):
+    ctx = MagicMock()
+    ctx.respond = AsyncMock()
+    ctx.guild = MagicMock() if guild else None
+    if guild:
+        member = MagicMock()
+        member.premium_since = datetime.datetime.now() if is_booster else None
+        ctx.guild.get_member = MagicMock(return_value=member)
+        ctx.user = MagicMock()
+        ctx.user.id = 1
+    return ctx
+
+
+async def test_boost_only_passes_for_booster():
+    ctx = _mw_make_ctx_boost(is_booster=True)
+    proceed = AsyncMock()
+    await boost_only()(ctx, proceed)
+    proceed.assert_called_once()
+
+
+async def test_boost_only_blocks_non_booster():
+    ctx = _mw_make_ctx_boost(is_booster=False)
+    proceed = AsyncMock()
+    await boost_only()(ctx, proceed)
+    proceed.assert_not_called()
+    assert ctx.respond.call_args.kwargs.get("ephemeral") is True
+
+
+async def test_boost_only_blocks_when_member_not_cached():
+    ctx = _mw_make_ctx_boost(guild=True)
+    ctx.guild.get_member = MagicMock(return_value=None)
+    proceed = AsyncMock()
+    await boost_only()(ctx, proceed)
+    proceed.assert_not_called()
+
+
+async def test_boost_only_passes_in_dm():
+    ctx = _mw_make_ctx_boost(guild=False)
+    proceed = AsyncMock()
+    await boost_only()(ctx, proceed)
+    proceed.assert_called_once()
+
+
+async def test_boost_only_custom_message():
+    ctx = _mw_make_ctx_boost(is_booster=False)
+    proceed = AsyncMock()
+    await boost_only(message="Boosters only!")(ctx, proceed)
+    assert "Boosters only!" in ctx.respond.call_args[0][0]
+
+
+def _mw_make_ctx_perms(*, guild=True, perms=None):
+    ctx = MagicMock()
+    ctx.respond = AsyncMock()
+    ctx.guild = MagicMock() if guild else None
+    if guild:
+        member = MagicMock()
+        gp = MagicMock()
+        for perm in (perms or []):
+            setattr(gp, perm, True)
+        member.guild_permissions = gp
+        ctx.guild.get_member = MagicMock(return_value=member)
+        ctx.user = MagicMock()
+        ctx.user.id = 1
+    return ctx
+
+
+async def test_has_permission_passes_when_member_has_all():
+    ctx = _mw_make_ctx_perms(perms=["kick_members", "ban_members"])
+    proceed = AsyncMock()
+    await has_permission("kick_members", "ban_members")(ctx, proceed)
+    proceed.assert_called_once()
+
+
+async def test_has_permission_blocks_when_missing_one():
+    ctx = _mw_make_ctx_perms(perms=["kick_members"])
+    ctx.guild.get_member.return_value.guild_permissions.ban_members = False
+    proceed = AsyncMock()
+    await has_permission("kick_members", "ban_members")(ctx, proceed)
+    proceed.assert_not_called()
+    assert ctx.respond.call_args.kwargs.get("ephemeral") is True
+    assert "ban_members" in ctx.respond.call_args[0][0]
+
+
+async def test_has_permission_blocks_when_member_not_cached():
+    ctx = _mw_make_ctx_perms(guild=True)
+    ctx.guild.get_member = MagicMock(return_value=None)
+    proceed = AsyncMock()
+    await has_permission("kick_members")(ctx, proceed)
+    proceed.assert_not_called()
+
+
+async def test_has_permission_passes_in_dm():
+    ctx = _mw_make_ctx_perms(guild=False)
+    proceed = AsyncMock()
+    await has_permission("kick_members")(ctx, proceed)
+    proceed.assert_called_once()

--- a/tests/test_tags_plugin.py
+++ b/tests/test_tags_plugin.py
@@ -1,0 +1,164 @@
+"""Tests for easycord.plugins.tags — TagsStore and TagsPlugin."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import discord
+
+from easycord.plugins.tags import TagsStore, TagsPlugin
+
+
+# ── TagsStore ─────────────────────────────────────────────────────────────────
+
+def test_store_get_missing_returns_none(tmp_path):
+    store = TagsStore(str(tmp_path))
+    assert store.get(1, "missing") is None
+
+
+def test_store_set_and_get(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.set(1, "hello", "Hello, world!", author_id=42)
+    entry = store.get(1, "hello")
+    assert entry["text"] == "Hello, world!"
+    assert entry["author_id"] == 42
+
+
+def test_store_set_overwrites(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.set(1, "greet", "Hi", author_id=1)
+    store.set(1, "greet", "Hello", author_id=2)
+    assert store.get(1, "greet")["text"] == "Hello"
+
+
+def test_store_delete_existing(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.set(1, "bye", "Goodbye", author_id=99)
+    store.delete(1, "bye")
+    assert store.get(1, "bye") is None
+
+
+def test_store_delete_missing_is_noop(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.delete(1, "nonexistent")  # should not raise
+
+
+def test_store_list_names_empty(tmp_path):
+    store = TagsStore(str(tmp_path))
+    assert store.list_names(1) == []
+
+
+def test_store_list_names_sorted(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.set(1, "zebra", "z", author_id=1)
+    store.set(1, "apple", "a", author_id=1)
+    assert store.list_names(1) == ["apple", "zebra"]
+
+
+def test_store_persists_across_instances(tmp_path):
+    TagsStore(str(tmp_path)).set(1, "persistent", "yes", author_id=5)
+    assert TagsStore(str(tmp_path)).get(1, "persistent")["text"] == "yes"
+
+
+def test_store_guild_isolation(tmp_path):
+    store = TagsStore(str(tmp_path))
+    store.set(1, "shared", "guild1", author_id=1)
+    assert store.get(2, "shared") is None
+
+
+# ── TagsPlugin ────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def store(tmp_path):
+    return TagsStore(str(tmp_path))
+
+
+@pytest.fixture
+def plugin(tmp_path):
+    return TagsPlugin(data_dir=str(tmp_path))
+
+
+def _make_ctx(guild_id=1, user_id=10, is_admin=False):
+    ctx = MagicMock()
+    ctx.guild_id = guild_id
+    ctx.respond = AsyncMock()
+    ctx.guild = MagicMock()
+    ctx.guild.id = guild_id
+    member = MagicMock(spec=discord.Member)
+    member.guild_permissions = MagicMock()
+    member.guild_permissions.administrator = is_admin
+    ctx.guild.get_member = MagicMock(return_value=member)
+    ctx.user = MagicMock()
+    ctx.user.id = user_id
+    return ctx
+
+
+async def test_tag_get_missing(plugin):
+    ctx = _make_ctx()
+    await plugin.get(ctx, name="nope")
+    ctx.respond.assert_called_once_with("Tag `nope` not found.", ephemeral=True)
+
+
+async def test_tag_get_found(plugin):
+    plugin._store.set(1, "hello", "Hello, world!", author_id=10)
+    ctx = _make_ctx()
+    await plugin.get(ctx, name="hello")
+    ctx.respond.assert_called_once_with("Hello, world!")
+
+
+async def test_tag_set_creates(plugin):
+    ctx = _make_ctx()
+    await plugin.set(ctx, name="greet", text="Hi there")
+    ctx.respond.assert_called_once_with("Tag `greet` saved.", ephemeral=True)
+    assert plugin._store.get(1, "greet")["text"] == "Hi there"
+
+
+async def test_tag_set_overwrites(plugin):
+    plugin._store.set(1, "greet", "Old", author_id=10)
+    ctx = _make_ctx()
+    await plugin.set(ctx, name="greet", text="New")
+    assert plugin._store.get(1, "greet")["text"] == "New"
+
+
+async def test_tag_delete_by_creator(plugin):
+    plugin._store.set(1, "bye", "Goodbye", author_id=10)
+    ctx = _make_ctx(user_id=10)
+    await plugin.delete(ctx, name="bye")
+    ctx.respond.assert_called_once_with("Tag `bye` deleted.", ephemeral=True)
+    assert plugin._store.get(1, "bye") is None
+
+
+async def test_tag_delete_by_admin(plugin):
+    plugin._store.set(1, "bye", "Goodbye", author_id=99)
+    ctx = _make_ctx(user_id=1, is_admin=True)
+    await plugin.delete(ctx, name="bye")
+    assert plugin._store.get(1, "bye") is None
+
+
+async def test_tag_delete_denied(plugin):
+    plugin._store.set(1, "bye", "Goodbye", author_id=99)
+    ctx = _make_ctx(user_id=10, is_admin=False)
+    await plugin.delete(ctx, name="bye")
+    ctx.respond.assert_called_once_with(
+        "You can only delete your own tags (or be an admin).", ephemeral=True
+    )
+    assert plugin._store.get(1, "bye") is not None
+
+
+async def test_tag_delete_missing(plugin):
+    ctx = _make_ctx()
+    await plugin.delete(ctx, name="ghost")
+    ctx.respond.assert_called_once_with("Tag `ghost` not found.", ephemeral=True)
+
+
+async def test_tag_list_empty(plugin):
+    ctx = _make_ctx()
+    await plugin.list(ctx)
+    ctx.respond.assert_called_once_with("No tags yet.", ephemeral=True)
+
+
+async def test_tag_list_shows_names(plugin):
+    plugin._store.set(1, "b", "B", author_id=1)
+    plugin._store.set(1, "a", "A", author_id=1)
+    ctx = _make_ctx()
+    await plugin.list(ctx)
+    ctx.respond.assert_called_once_with("**Tags:**\na\nb", ephemeral=True)


### PR DESCRIPTION
…w middleware

- @bot.component: persistent button/select-menu routing with prefix matching
- _GuildMixin: fetch_guild, fetch_channel, leave_guild, create/delete channel, send_webhook (auto-cached), create/delete/fetch emojis
- ctx.fetch_member, ctx.bot_permissions, ctx.typing(), ctx.fetch_pinned_messages
- boost_only() and has_permission() middleware factories
- set_status: add "streaming" activity type
- README: navigation TOC, new sections for all features
- docs/index.md: before/after comparisons for components, permissions, webhooks
- docs/api.md: full documentation for all new methods

## Summary by Sourcery

Add component interaction routing, guild management helpers, context utilities, and new permission/booster middleware, with full tests and documentation updates.

New Features:
- Support streaming activity in bot.set_status presence updates.
- Introduce @bot.component decorator with exact and prefix-based routing for persistent button/select-menu interactions, integrated with middleware.
- Add _GuildMixin with helpers for cache-first guild/channel fetch, guild leave, channel create/delete, webhook sending with per-channel caching, and emoji management.
- Extend Context with fetch_member, bot_permissions, typing(), and fetch_pinned_messages helpers for guild and channel operations.
- Provide boost_only and has_permission middleware factories for gating commands by booster status or specific Discord permissions.

Documentation:
- Expand README and docs to cover persistent components, permission-gated middleware, guild/channel/webhook/emoji management, new context helpers, and updated set_status behavior.
- Update API reference tables with new Bot and Context methods and middleware entries.

Tests:
- Add comprehensive tests for set_status streaming activity, guild and channel helpers, webhook caching behavior, emoji utilities, context helpers, component routing, and new middleware behavior.