### PR TITLE
[codex] address PR review comments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,10 @@ need, then register a few slash commands on top.
 
 `Bot.add_plugins(*plugins)` — load several plugins in one call
 
+`Bot.add_group(group)` — load one SlashGroup namespace; raises `TypeError` / `ValueError` on bad input or duplicate
+
+`Bot.add_groups(*groups)` — load several SlashGroup namespaces in one call
+
 `await Bot.remove_plugin(plugin)` — unload plugin; removes commands, deregisters handlers, calls `on_unload()`
 
 `await Bot.reload_plugin(name: str)` — reload a plugin in-place by class name; calls `on_unload()` then `on_load()` on the same instance; constructor arguments and in-memory state preserved; raises `ValueError` if no loaded plugin has that class name
@@ -314,6 +318,8 @@ Fluent builder — chains middleware + plugins, returns a configured `Bot`.
 | `.use(middleware)` | Add custom middleware |
 | `.add_plugin(plugin)` | Queue a plugin |
 | `.add_plugins(*plugins)` | Queue several plugins |
+| `.add_group(group)` | Queue a SlashGroup namespace |
+| `.add_groups(*groups)` | Queue several SlashGroup namespaces |
 | `.build()` | Return configured `Bot` |
 
 ---

--- a/docs/fork-and-expand.md
+++ b/docs/fork-and-expand.md
@@ -24,10 +24,12 @@ Use `bot.py` only for startup and plugin loading:
 ```python
 import os
 from easycord import Bot
-from server_commands import load_default_plugins
+from plugins.fun import FunPlugin
+from plugins.info import InfoPlugin
+from plugins.moderation import ModerationPlugin
 
 bot = Bot()
-load_default_plugins(bot)
+bot.add_plugins(FunPlugin(), ModerationPlugin(), InfoPlugin())
 bot.run(os.environ["DISCORD_TOKEN"])
 ```
 
@@ -36,7 +38,7 @@ bot.run(os.environ["DISCORD_TOKEN"])
 1. Create a new plugin module in `plugins/`, for example `plugins/music.py`.
 2. Put one related feature set in that file.
 3. Use `@slash`, `@on`, `@component`, or `@modal` as needed.
-4. Load the plugin from `bot.py` or add it to `server_commands/__init__.py` if it should be part of the default bot setup.
+4. Load the plugin from `bot.py`, or gather the always-on plugins in one small startup helper if several features should ship together.
 
 ```python
 from easycord import Plugin, slash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,7 @@ class FunPlugin(Plugin):
 Then load it from `bot.py`:
 
 ```python
+import os
 from easycord import Bot
 from server_commands import load_default_plugins
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,7 @@
 # Release notes for 3.1.0
 
+Release date: 2026-04-22
+
 This update focuses on two things: making the framework easier to learn, and exposing more of the `discord.py` features that beginners keep reaching for.
 
 ## What changed
@@ -23,3 +25,5 @@ This update focuses on two things: making the framework easier to learn, and exp
 
 - `python -m pytest tests/test_group.py tests/test_bot.py tests/test_composer.py tests/test_server_commands.py tests/test_package_exports.py tests/test_decorators.py`
 - `python -m compileall easycord examples docs tests`
+
+Note: On Windows, pytest may emit temp/cache permission warnings that can be safely ignored if the test slice passes.

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -108,9 +108,6 @@ class _CommandsMixin:
         ephemeral: bool = False,
         permissions: list[str] | None = None,
         cooldown: float | None = None,
-        nsfw: bool = False,
-        allowed_contexts: discord.AppCommandContext | None = None,
-        allowed_installs: discord.AppInstallationType | None = None,
     ) -> Callable:
         """Build a discord.py-compatible callback with guild, permission, and cooldown guards."""
         sig = inspect.signature(func)

--- a/easycord/plugins/_shared.py
+++ b/easycord/plugins/_shared.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import discord
 
 
-def require_guild(ctx):
+def require_guild(ctx: object) -> discord.Guild | None:
     """Return the invoking guild, or ``None`` when the command ran in DMs."""
     return getattr(ctx, "guild", None)
 
@@ -22,8 +22,12 @@ def read_json_file(path: Path) -> dict:
     """Read a JSON file if it exists, otherwise return an empty mapping."""
     if not path.exists():
         return {}
-    with path.open(encoding="utf-8") as handle:
-        return json.load(handle)
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def write_json_file(path: Path, data: dict) -> None:

--- a/easycord/plugins/levels.py
+++ b/easycord/plugins/levels.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import time
 from collections import defaultdict
+from typing import Any
 
 import discord
 
@@ -123,7 +124,14 @@ class LevelsPlugin(Plugin):
     def _build_ranks_embed(self, ctx, config: dict) -> discord.Embed:
         rank_map: dict[str, str] = config.get("ranks", {})
         role_map: dict[str, int] = config.get("role_rewards", {})
-        all_levels = sorted(set(rank_map) | set(role_map), key=int)
+        all_levels: list[str] = []
+        for level_key in set(rank_map) | set(role_map):
+            try:
+                int(level_key)
+            except (TypeError, ValueError):
+                continue
+            all_levels.append(level_key)
+        all_levels.sort(key=int)
         lines = []
         for lvl_str in all_levels:
             parts = [f"**Level {lvl_str}**"]
@@ -145,8 +153,10 @@ class LevelsPlugin(Plugin):
 
         await self._store.update_config(guild_id, updater)
 
-    async def _remove_config_value(self, guild_id: int, section: str, key: int):
-        def updater(config: dict):
+    async def _remove_config_value(
+        self, guild_id: int, section: str, key: int
+    ) -> Any | None:
+        def updater(config: dict) -> Any | None:
             return config.get(section, {}).pop(str(key), None)
 
         return await self._store.update_config(guild_id, updater)

--- a/easycord/plugins/welcome.py
+++ b/easycord/plugins/welcome.py
@@ -148,8 +148,15 @@ class WelcomePlugin(Plugin):
         if guild is None:
             await ctx.respond("This command only works in a server.", ephemeral=True)
             return
+        try:
+            preview = format_template(message, user=ctx.user.mention, server=guild.name)
+        except (KeyError, ValueError):
+            await ctx.respond(
+                "Invalid template. Only {user} and {server} placeholders are supported.",
+                ephemeral=True,
+            )
+            return
         self._update(guild.id, welcome_message=message)
-        preview = format_template(message, user=ctx.user.mention, server=guild.name)
         await ctx.respond(f"Welcome message updated!\n**Preview:** {preview}", ephemeral=True)
 
     @slash(description="Customise the goodbye message. Use {user} and {server} as placeholders.", permissions=["manage_guild"])
@@ -158,8 +165,15 @@ class WelcomePlugin(Plugin):
         if guild is None:
             await ctx.respond("This command only works in a server.", ephemeral=True)
             return
+        try:
+            preview = format_template(message, user=str(ctx.user), server=guild.name)
+        except (KeyError, ValueError):
+            await ctx.respond(
+                "Invalid template. Only {user} and {server} placeholders are supported.",
+                ephemeral=True,
+            )
+            return
         self._update(guild.id, goodbye_message=message)
-        preview = format_template(message, user=str(ctx.user), server=guild.name)
         await ctx.respond(f"Goodbye message updated!\n**Preview:** {preview}", ephemeral=True)
 
     @slash(description="Show the current welcome configuration for this server.")

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example bots and shared runtime helpers."""

--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -2,7 +2,7 @@
 
 from easycord import Bot
 
-from _runtime import run_bot
+from examples._runtime import run_bot
 
 
 def build_bot() -> Bot:

--- a/examples/group_bot.py
+++ b/examples/group_bot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from easycord import Composer, SlashGroup, slash
 
-from examples._runtime import read_token, run_bot
+from examples._runtime import run_bot
 
 
 class ModerationGroup(SlashGroup, name="mod", description="Moderation commands"):
@@ -23,7 +23,7 @@ def build_bot():
 
 
 def main() -> None:
-    run_bot(build_bot(), read_token())
+    run_bot(build_bot())
 
 
 if __name__ == "__main__":

--- a/examples/plugin_bot.py
+++ b/examples/plugin_bot.py
@@ -13,7 +13,7 @@ Run:
 from easycord import Bot
 from server_commands import load_default_plugins
 
-from _runtime import run_bot
+from examples._runtime import run_bot
 
 
 def build_bot() -> Bot:

--- a/server_commands/__init__.py
+++ b/server_commands/__init__.py
@@ -3,7 +3,7 @@ Server command plugins.
 
 Import plugins from here (or from individual modules) and load them into your bot:
 
-    from server_commands import FunPlugin, ModerationPlugin, InfoPlugin
+    from server_commands import FunPlugin, ModerationPlugin, InfoPlugin, load_default_plugins
     load_default_plugins(bot)
 """
 

--- a/server_commands/moderation.py
+++ b/server_commands/moderation.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+import logging
+
+import discord
 from easycord import Plugin, on, slash
+
+logger = logging.getLogger(__name__)
 
 
 def _announcement_footer(user) -> str:
@@ -20,7 +27,6 @@ class ModerationPlugin(Plugin):
 
     @slash(description="Announce a message to this channel.", guild_only=True)
     async def announce(self, ctx, message: str):
-        import discord
         await ctx.send_embed(
             "📢 Announcement",
             message,
@@ -33,5 +39,11 @@ class ModerationPlugin(Plugin):
         """DM new members a welcome message."""
         try:
             await member.send(_welcome_message(member))
-        except Exception:
-            pass
+        except discord.Forbidden:
+            return
+        except discord.HTTPException:
+            logger.warning("Failed sending welcome DM to %s", member, exc_info=True)
+            return
+        except Exception as exc:
+            logger.exception("Failed sending welcome DM to %s: %s", member, exc)
+            raise

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -94,22 +94,42 @@ def test_slash_guild_scoped(bot):
 
 
 def test_slash_nsfw_flag_is_forwarded(bot):
-    @bot.slash(description="Secret", nsfw=True)
+    contexts = discord.AppCommandContext(guild=True, dm_channel=False, private_channel=True)
+    installs = discord.AppInstallationType(guild=True, user=False)
+
+    @bot.slash(
+        description="Secret",
+        nsfw=True,
+        allowed_contexts=contexts,
+        allowed_installs=installs,
+    )
     async def secret(ctx):
         pass
 
     cmd = bot.tree.add_command.call_args[0][0]
     assert getattr(cmd, "nsfw", False) is True
+    assert getattr(cmd, "allowed_contexts", None) == contexts
+    assert getattr(cmd, "allowed_installs", None) == installs
 
 
 def test_user_command_metadata_is_forwarded(bot):
-    @bot.user_command(name="Inspect", nsfw=True)
+    contexts = discord.AppCommandContext(guild=False, dm_channel=True, private_channel=False)
+    installs = discord.AppInstallationType(guild=False, user=True)
+
+    @bot.user_command(
+        name="Inspect",
+        nsfw=True,
+        allowed_contexts=contexts,
+        allowed_installs=installs,
+    )
     async def inspect_user(ctx, member):
         pass
 
     cmd = bot.tree.add_command.call_args[0][0]
     assert cmd.name == "Inspect"
     assert getattr(cmd, "nsfw", False) is True
+    assert getattr(cmd, "allowed_contexts", None) == contexts
+    assert getattr(cmd, "allowed_installs", None) == installs
 
 
 async def test_slash_guild_only_blocks_dm(bot):

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -125,7 +125,10 @@ def test_add_groups_registers_many():
         pass
 
     a, b = A(), B()
-    bot = Composer().add_groups(a, b).build()
+    composer = Composer().add_groups(a, b)
+    assert composer._groups == [a, b]
+
+    bot = composer.build()
     assert bot._plugins == [a, b]
 
 

--- a/tests/test_server_commands.py
+++ b/tests/test_server_commands.py
@@ -36,3 +36,27 @@ def test_load_default_plugins_registers_each_plugin():
     assert isinstance(bot.plugins[0], FunPlugin)
     assert isinstance(bot.plugins[1], ModerationPlugin)
     assert isinstance(bot.plugins[2], InfoPlugin)
+
+
+def test_load_default_plugins_prefers_bulk_add_plugins():
+    class Collector:
+        def __init__(self):
+            self.plugins = []
+            self.calls = 0
+
+        def add_plugins(self, *plugins):
+            self.calls += 1
+            self.plugins.extend(plugins)
+
+        def add_plugin(self, plugin):
+            raise AssertionError("fallback path should not be used when add_plugins exists")
+
+    bot = Collector()
+
+    load_default_plugins(bot)
+
+    assert bot.calls == 1
+    assert len(bot.plugins) == 3
+    assert isinstance(bot.plugins[0], FunPlugin)
+    assert isinstance(bot.plugins[1], ModerationPlugin)
+    assert isinstance(bot.plugins[2], InfoPlugin)


### PR DESCRIPTION
## What changed
- Fixed the grouped bot example runtime bug by calling `run_bot(build_bot())` with the correct signature.
- Aligned the docs with the bulk plugin/group APIs and the current beginner-facing examples.
- Hardened the shared plugin helpers and bundled plugins against malformed data and unsafe exception swallowing.
- Expanded test coverage for the new metadata forwarding and bulk registration paths.

## Why
These changes close out the review feedback from the refactor PR and make the follow-up cleanup safer and easier to use.

## Validation
- `python -m compileall .\easycord .\examples .\docs .\tests`
- `python -m pytest .\tests\test_bot.py .\tests\test_group.py .\tests\test_composer.py .\tests\test_server_commands.py .\tests\test_package_exports.py .\tests\test_decorators.py`

## Notes
- The Windows pytest temp/cache permission warning still appears in this environment, but the focused test slice passes.

## Summary by Sourcery

Tighten plugin safety and metadata handling while aligning examples, docs, and tests with the new bulk APIs and runtime helpers.

Bug Fixes:
- Fix the grouped bot example to call the shared runtime helper with the correct signature.

Enhancements:
- Harden plugin config and template handling against malformed JSON and invalid placeholders, with clearer error messaging instead of silent failures.
- Restrict level rank rendering to numeric keys and type-hint internal helpers to better signal expected inputs and outputs.
- Replace blanket exception swallowing in moderation welcome DMs with granular error handling and logging, ensuring unexpected errors propagate.

Documentation:
- Update getting-started, fork-and-expand, API, and release-notes docs to showcase bulk plugin/group loading, composer group support, and current example usage patterns.

Tests:
- Extend bot, server command, and composer tests to cover metadata forwarding (contexts/installs), default plugin bulk loading, and composer group accumulation.
- Add a package marker for the examples directory so imports from examples resolve consistently across environments.

Chores:
- Clarify server_commands public API docs to include the default plugin loader helper.