### PR TITLE
feat: localization — LocalizationManager, ctx.t(), i18n middleware guards

### DIFF
--- a/easycord/__init__.py
+++ b/easycord/__init__.py
@@ -24,6 +24,7 @@ from .composer import Composer
 from .context import Context
 from .database import DatabaseConfig, EasyCordDatabase, GuildRecord, MemoryDatabase, SQLiteDatabase
 from .decorators import component, message_command, modal, on, slash, task, user_command
+from .i18n import LocalizationManager
 from .group import SlashGroup
 from .plugin import Plugin
 from .server_config import ServerConfig, ServerConfigStore
@@ -46,6 +47,7 @@ __all__ = [
     "message_command",
     "modal",
     "MemoryDatabase",
+    "LocalizationManager",
     "Plugin",
     "SelectMenuBuilder",
     "SlashGroup",

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -122,21 +122,31 @@ class _CommandsMixin:
             async def invoke() -> None:
                 if guild_only and not ctx.guild:
                     await ctx.respond(
-                        "This command can only be used inside a server.",
+                        ctx.t(
+                            "errors.guild_only",
+                            default="This command can only be used inside a server.",
+                        ),
                         ephemeral=True,
                     )
                     return
                 if permissions:
                     if not ctx.guild:
                         await ctx.respond(
-                            "This command can only be used inside a server.",
+                            ctx.t(
+                                "errors.guild_only",
+                                default="This command can only be used inside a server.",
+                            ),
                             ephemeral=True,
                         )
                         return
                     member = ctx.guild.get_member(ctx.user.id)
                     if not member:
                         await ctx.respond(
-                            "Could not verify your permissions.", ephemeral=True
+                            ctx.t(
+                                "errors.permissions_unverified",
+                                default="Could not verify your permissions.",
+                            ),
+                            ephemeral=True,
                         )
                         return
                     missing = [
@@ -145,8 +155,11 @@ class _CommandsMixin:
                     ]
                     if missing:
                         await ctx.respond(
-                            f"You need the following permission(s): "
-                            f"{', '.join(missing)}.",
+                            ctx.t(
+                                "errors.permissions_missing",
+                                default="You need the following permission(s): {permissions}.",
+                                permissions=", ".join(missing),
+                            ),
                             ephemeral=True,
                         )
                         return
@@ -156,8 +169,11 @@ class _CommandsMixin:
                     remaining = cooldown - (now - _cooldown_last_used.get(uid, 0.0))
                     if remaining > 0:
                         await ctx.respond(
-                            f"This command is on cooldown. "
-                            f"Try again in {remaining:.1f}s.",
+                            ctx.t(
+                                "errors.cooldown",
+                                default="This command is on cooldown. Try again in {seconds:.1f}s.",
+                                seconds=remaining,
+                            ),
                             ephemeral=True,
                         )
                         return

--- a/easycord/_context_base.py
+++ b/easycord/_context_base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import discord
 
+from .i18n import LocalizationManager
+
 
 class BaseContext:
     """Core wrapper around ``discord.Interaction``.
@@ -43,6 +45,16 @@ class BaseContext:
         return cmd.name if cmd is not None else None
 
     @property
+    def locale(self):
+        """The locale selected by the invoking user, if Discord provides one."""
+        return getattr(self.interaction, "locale", None)
+
+    @property
+    def guild_locale(self):
+        """The preferred locale for the current guild, if Discord provides one."""
+        return getattr(self.interaction, "guild_locale", None)
+
+    @property
     def data(self) -> dict | None:
         """The raw interaction data from Discord."""
         return self.interaction.data  # type: ignore[return-value]
@@ -58,6 +70,29 @@ class BaseContext:
         if isinstance(member, discord.Member) and member.voice:
             return member.voice.channel  # type: ignore[return-value]
         return None
+
+    def t(
+        self,
+        key: str,
+        *,
+        default: str | None = None,
+        locale=None,
+        guild_locale=None,
+        **kwargs,
+    ) -> str:
+        """Translate a key using the bot's localization manager if available."""
+        client = getattr(self.interaction, "client", None)
+        localization = getattr(client, "localization", None) or getattr(client, "i18n", None)
+        if not isinstance(localization, LocalizationManager):
+            template = default if default is not None else key
+            return template.format(**kwargs)
+        return localization.format(
+            key,
+            locale=locale if locale is not None else self.locale,
+            guild_locale=guild_locale if guild_locale is not None else self.guild_locale,
+            default=default,
+            **kwargs,
+        )
 
     # ── Responding ────────────────────────────────────────────
 

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -11,6 +11,7 @@ from discord import app_commands
 
 from .builtin_plugins import build_builtin_plugins
 from .database import DatabaseConfig, EasyCordDatabase, MemoryDatabase, SQLiteDatabase
+from .i18n import LocalizationManager
 from .middleware import MiddlewareFn
 from .plugin import Plugin
 from ._bot_commands import _CommandsMixin
@@ -62,6 +63,9 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
         db_backend: str | None = None,
         db_path: str | None = None,
         db_auto_sync_guilds: bool | None = None,
+        localization: LocalizationManager | None = None,
+        default_locale: str = "en-US",
+        translations: dict | None = None,
         **kwargs,
     ) -> None:
         super().__init__(intents=intents or discord.Intents.default(), **kwargs)
@@ -78,6 +82,11 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
             db_backend=db_backend,
             db_path=db_path,
             db_auto_sync_guilds=db_auto_sync_guilds,
+        )
+        self.localization: LocalizationManager | None = localization or (
+            LocalizationManager(default_locale=default_locale, translations=translations)
+            if translations
+            else None
         )
         if load_builtin_plugins:
             self.load_builtin_plugins()

--- a/easycord/i18n.py
+++ b/easycord/i18n.py
@@ -1,0 +1,105 @@
+"""Lightweight localization helpers for EasyCord."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _normalize_locale(locale: Any) -> str | None:
+    if locale is None:
+        return None
+    if hasattr(locale, "value"):
+        locale = locale.value
+    text = str(locale).strip()
+    if not text:
+        return None
+    return text.replace("_", "-")
+
+
+class LocalizationManager:
+    """Store and resolve string templates by locale.
+
+    The manager keeps a dictionary of catalogs keyed by locale string. A lookup
+    checks the interaction locale first, then the guild locale, then the
+    configured default locale, and finally a simple language-only fallback
+    (for example ``pt-BR`` → ``pt``).
+    """
+
+    def __init__(
+        self,
+        *,
+        default_locale: str = "en-US",
+        translations: Mapping[str, Mapping[str, str]] | None = None,
+    ) -> None:
+        self.default_locale = _normalize_locale(default_locale) or "en-US"
+        self._catalogs: dict[str, dict[str, str]] = {}
+        for locale, values in (translations or {}).items():
+            self.register(locale, values)
+
+    def register(self, locale: Any, translations: Mapping[str, str]) -> None:
+        """Register or merge a locale catalog."""
+        normalized = _normalize_locale(locale)
+        if normalized is None:
+            raise ValueError("locale must be a non-empty string")
+        self._catalogs.setdefault(normalized, {}).update(
+            {str(key): str(value) for key, value in translations.items()}
+        )
+
+    def locales(self) -> list[str]:
+        """Return the known locale tags."""
+        return sorted(self._catalogs)
+
+    def resolve_chain(
+        self,
+        locale: Any = None,
+        *,
+        guild_locale: Any = None,
+    ) -> list[str]:
+        """Return the fallback chain for a locale lookup."""
+        chain: list[str] = []
+        for candidate in (
+            _normalize_locale(locale),
+            _normalize_locale(guild_locale),
+            self.default_locale,
+        ):
+            if not candidate:
+                continue
+            parts = candidate.split("-")
+            for index in range(len(parts), 0, -1):
+                value = "-".join(parts[:index])
+                if value not in chain:
+                    chain.append(value)
+        return chain
+
+    def get(
+        self,
+        key: str,
+        *,
+        locale: Any = None,
+        guild_locale: Any = None,
+        default: str | None = None,
+    ) -> str:
+        """Look up a translated string and fall back safely if missing."""
+        for candidate in self.resolve_chain(locale, guild_locale=guild_locale):
+            catalog = self._catalogs.get(candidate)
+            if catalog and key in catalog:
+                return catalog[key]
+        return default if default is not None else key
+
+    def format(
+        self,
+        key: str,
+        *,
+        locale: Any = None,
+        guild_locale: Any = None,
+        default: str | None = None,
+        **kwargs,
+    ) -> str:
+        """Look up a translated string and format it with keyword arguments."""
+        template = self.get(
+            key,
+            locale=locale,
+            guild_locale=guild_locale,
+            default=default,
+        )
+        return template.format(**kwargs)

--- a/easycord/middleware.py
+++ b/easycord/middleware.py
@@ -43,7 +43,11 @@ def dm_only() -> MiddlewareFn:
     async def handler(ctx: Context, proceed: Callable[[], Awaitable[None]]) -> None:
         if ctx.guild is not None:
             await ctx.respond(
-                "This command can only be used in a direct message.", ephemeral=True
+                ctx.t(
+                    "errors.dm_only",
+                    default="This command can only be used in a direct message.",
+                ),
+                ephemeral=True,
             )
             return
         await proceed()
@@ -155,7 +159,11 @@ def guild_only() -> MiddlewareFn:
     async def handler(ctx: Context, proceed: Callable[[], Awaitable[None]]) -> None:
         if ctx.guild is None:
             await ctx.respond(
-                "This command can only be used inside a server.", ephemeral=True
+                ctx.t(
+                    "errors.guild_only",
+                    default="This command can only be used inside a server.",
+                ),
+                ephemeral=True,
             )
             return
         await proceed()
@@ -183,7 +191,11 @@ def rate_limit(
         if len(_history[uid]) >= limit:
             wait = window - (now - _history[uid][0])
             await ctx.respond(
-                f"You're being rate limited. Try again in {wait:.1f}s.",
+                ctx.t(
+                    "errors.rate_limited",
+                    default="You're being rate limited. Try again in {seconds:.1f}s.",
+                    seconds=wait,
+                ),
                 ephemeral=True,
             )
             return

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,28 @@
+from easycord.i18n import LocalizationManager
+
+
+def test_register_and_get_translation():
+    i18n = LocalizationManager()
+    i18n.register("es-ES", {"errors.guild_only": "Solo servidores"})
+
+    assert i18n.get("errors.guild_only", locale="es-ES") == "Solo servidores"
+
+
+def test_fallback_to_language_and_default_locale():
+    i18n = LocalizationManager(default_locale="en-US")
+    i18n.register("pt", {"hello": "olá"})
+
+    assert i18n.get("hello", locale="pt-BR") == "olá"
+
+
+def test_format_interpolates_values():
+    i18n = LocalizationManager()
+    i18n.register("en-US", {"errors.cooldown": "Wait {seconds:.1f}s"})
+
+    assert i18n.format("errors.cooldown", locale="en-US", seconds=2.5) == "Wait 2.5s"
+
+
+def test_missing_key_falls_back_to_default_text():
+    i18n = LocalizationManager()
+
+    assert i18n.get("missing.key", default="fallback") == "fallback"


### PR DESCRIPTION
## Summary

Ports the v3.1.3 localization work cleanly onto the current main (v3.2.0 base). The original PR #5 had conflicts because main jumped past it; this PR contains exactly the same localization additions with no removals.

- `easycord/i18n.py` — new `LocalizationManager` with locale fallback chain (`pt-BR` → `pt` → `en-US`)
- `_context_base.py` — `ctx.locale`, `ctx.guild_locale`, `ctx.t(key, ...)` translation helper
- `bot.py` — `Bot(localization=, default_locale=, translations=)` constructor params
- `_bot_commands.py` — guild_only, permissions, cooldown guards use `ctx.t()` with English defaults
- `middleware.py` — `dm_only()`, `guild_only()`, `rate_limit()` guards use `ctx.t()` with English defaults
- `__init__.py` — exports `LocalizationManager`
- `tests/test_i18n.py` — unit tests: register, fallback, format, missing key

## Test plan

- [x] 452 tests passing (`pytest`)
- [x] `LocalizationManager` fallback chain verified (`pt-BR` → `pt`)
- [x] All built-in error strings go through `ctx.t()` — English defaults preserved for bots without i18n configured
- [x] No existing exports removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a lightweight localization system and integrate it into core bot context and error handling.

New Features:
- Add a LocalizationManager for managing locale-specific string catalogs with fallback resolution and formatting.
- Expose ctx.locale, ctx.guild_locale, and a ctx.t() helper for localized responses in command contexts.
- Allow the Bot to be configured with localization, default_locale, and translation catalogs, and export LocalizationManager from the top-level package.

Enhancements:
- Update built-in command and middleware guards to use localized error messages while preserving English defaults when localization is not configured.

Tests:
- Add unit tests covering localization registration, locale fallback behavior, template formatting, and missing-key handling.