### PR TITLE
i18n(middleware): localize default error messages

### DIFF
--- a/easycord/middleware.py
+++ b/easycord/middleware.py
@@ -55,7 +55,7 @@ def dm_only() -> MiddlewareFn:
     return handler
 
 
-def allowed_roles(*role_ids: int, message: str = "You don't have the required role to use this command.") -> MiddlewareFn:
+def allowed_roles(*role_ids: int, message: str | None = None) -> MiddlewareFn:
     """Block commands unless the invoking member holds at least one of *role_ids*.
 
     Silently passes when used outside a guild (DMs), so combine with
@@ -73,7 +73,11 @@ def allowed_roles(*role_ids: int, message: str = "You don't have the required ro
             return
         member = ctx.guild.get_member(ctx.user.id)
         if member is None or role_set.isdisjoint(r.id for r in member.roles):
-            await ctx.respond(message, ephemeral=True)
+            text = message or ctx.t(
+                "errors.missing_role",
+                default="You don't have the required role to use this command.",
+            )
+            await ctx.respond(text, ephemeral=True)
             return
         await proceed()
 
@@ -82,7 +86,7 @@ def allowed_roles(*role_ids: int, message: str = "You don't have the required ro
 
 def channel_only(
     *channel_ids: int,
-    message: str = "This command cannot be used in this channel.",
+    message: str | None = None,
 ) -> MiddlewareFn:
     """Block commands invoked outside of the specified channel(s).
 
@@ -99,7 +103,11 @@ def channel_only(
             await proceed()
             return
         if ctx.channel is None or ctx.channel.id not in channel_set:  # type: ignore[union-attr]
-            await ctx.respond(message, ephemeral=True)
+            text = message or ctx.t(
+                "errors.wrong_channel",
+                default="This command cannot be used in this channel.",
+            )
+            await ctx.respond(text, ephemeral=True)
             return
         await proceed()
 
@@ -107,7 +115,7 @@ def channel_only(
 
 
 def admin_only(
-    message: str = "This command requires administrator permissions.",
+    message: str | None = None,
 ) -> MiddlewareFn:
     """Block commands unless the invoking member has the administrator permission.
 
@@ -125,7 +133,11 @@ def admin_only(
             return
         member = ctx.guild.get_member(ctx.user.id)
         if member is None or not member.guild_permissions.administrator:
-            await ctx.respond(message, ephemeral=True)
+            text = message or ctx.t(
+                "errors.admin_only",
+                default="This command requires administrator permissions.",
+            )
+            await ctx.respond(text, ephemeral=True)
             return
         await proceed()
 
@@ -207,7 +219,7 @@ def rate_limit(
 
 
 def boost_only(
-    message: str = "This command is for server boosters only.",
+    message: str | None = None,
 ) -> MiddlewareFn:
     """Block commands unless the invoking member is currently boosting the server.
 
@@ -225,7 +237,11 @@ def boost_only(
             return
         member = ctx.guild.get_member(ctx.user.id)
         if member is None or member.premium_since is None:
-            await ctx.respond(message, ephemeral=True)
+            text = message or ctx.t(
+                "errors.booster_only",
+                default="This command is for server boosters only.",
+            )
+            await ctx.respond(text, ephemeral=True)
             return
         await proceed()
 
@@ -255,19 +271,23 @@ def has_permission(
             return
         member = ctx.guild.get_member(ctx.user.id)
         if member is None:
-            await ctx.respond(
-                message or "Could not verify your permissions.", ephemeral=True
+            text = message or ctx.t(
+                "errors.permissions_unverified",
+                default="Could not verify your permissions.",
             )
+            await ctx.respond(text, ephemeral=True)
             return
         missing = [
             p for p in permissions
             if not getattr(member.guild_permissions, p, False)
         ]
         if missing:
-            await ctx.respond(
-                message or f"You need the following permission(s): {', '.join(missing)}.",
-                ephemeral=True,
+            text = message or ctx.t(
+                "errors.permissions_missing",
+                default="You need the following permission(s): {permissions}.",
+                permissions=", ".join(missing),
             )
+            await ctx.respond(text, ephemeral=True)
             return
         await proceed()
 
@@ -275,7 +295,7 @@ def has_permission(
 
 
 def catch_errors(
-    message: str = "Something went wrong. Please try again.",
+    message: str | None = None,
 ) -> MiddlewareFn:
     """Catch unhandled exceptions, log them, and send an ephemeral error reply."""
     logger = logging.getLogger("easycord")
@@ -286,6 +306,10 @@ def catch_errors(
         except Exception as exc:  # noqa: BLE001 — intentional broad catch for error handler
             logger.exception("Unhandled error in /%s: %s", ctx.command_name, exc)
             with contextlib.suppress(Exception):
-                await ctx.respond(message, ephemeral=True)
+                text = message or ctx.t(
+                    "errors.internal",
+                    default="Something went wrong. Please try again.",
+                )
+                await ctx.respond(text, ephemeral=True)
 
     return handler

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -423,12 +423,14 @@ async def test_has_permission_passes_when_member_has_all():
 
 async def test_has_permission_blocks_when_missing_one():
     ctx = _mw_make_ctx_perms(perms=["kick_members"])
+    ctx.t.return_value = "Missing permissions: ban_members"
     ctx.guild.get_member.return_value.guild_permissions.ban_members = False
     proceed = AsyncMock()
     await has_permission("kick_members", "ban_members")(ctx, proceed)
     proceed.assert_not_called()
     assert ctx.respond.call_args.kwargs.get("ephemeral") is True
-    assert "ban_members" in ctx.respond.call_args[0][0]
+    ctx.t.assert_called_once()
+    assert ctx.t.call_args.kwargs.get("permissions") == "ban_members"
 
 
 async def test_has_permission_blocks_when_member_not_cached():


### PR DESCRIPTION
Localize all middleware error messages via ctx.t().

Changes:
- Make message parameter optional (defaults to None)
- Use ctx.t() with localized fallback for: allowed_roles, channel_only, admin_only, boost_only, has_permission, catch_errors
- Add translation keys: errors.missing_role, errors.wrong_channel, errors.admin_only, errors.booster_only, errors.permissions_unverified, errors.permissions_missing, errors.internal
- Update tests to verify ctx.t() calls

Tests: 452 passing
Resolves: #11

## Summary by Sourcery

Localize middleware error responses through the translation system while preserving optional custom messages.

New Features:
- Add localization support for middleware error responses via ctx.t() with translation keys for common error cases.

Enhancements:
- Make middleware message parameters optional and fall back to translated defaults for role, channel, admin, booster, permission, and internal error checks.

Tests:
- Update middleware tests to assert that permission errors use ctx.t() with the correct parameters.