### PR TITLE
i18n(welcome): localize guild_only error message

### DIFF
--- a/easycord/plugins/welcome.py
+++ b/easycord/plugins/welcome.py
@@ -119,7 +119,13 @@ class WelcomePlugin(Plugin):
     async def set_welcome_channel(self, ctx, channel: discord.TextChannel) -> None:
         guild = require_guild(ctx)
         if guild is None:
-            await ctx.respond("This command only works in a server.", ephemeral=True)
+            await ctx.respond(
+                ctx.t(
+                    "errors.guild_only",
+                    default="This command only works in a server.",
+                ),
+                ephemeral=True,
+            )
             return
         self._update(guild.id, welcome_channel=channel.id)
         await ctx.respond(f"Welcome messages will be posted in {channel.mention}.", ephemeral=True)


### PR DESCRIPTION
Localize WelcomePlugin guild_only error.

Changes:
- Replace hardcoded 'This command only works in a server.' with ctx.t('errors.guild_only')

Tests: 15 passing
Resolves: #12

## Summary by Sourcery

New Features:
- Add translation key support for the welcome command's guild-only error message with a configurable default fallback.