### PR TITLE
i18n(tags): localize all user-facing messages

### DIFF
--- a/easycord/plugins/tags.py
+++ b/easycord/plugins/tags.py
@@ -54,35 +54,37 @@ class TagsPlugin(Plugin):
     async def get(self, ctx, name: str) -> None:
         entry = self._store.get(ctx.guild_id, name)
         if entry is None:
-            await ctx.respond(f"Tag `{name}` not found.", ephemeral=True)
+            await ctx.respond(ctx.t("tags.not_found", default="Tag `{name}` not found.", name=name), ephemeral=True)
             return
         await ctx.respond(entry["text"])
 
     @slash(description="Create or update a tag.", guild_only=True)
     async def set(self, ctx, name: str, text: str) -> None:
         self._store.set(ctx.guild_id, name, text, author_id=ctx.user.id)
-        await ctx.respond(f"Tag `{name}` saved.", ephemeral=True)
+        await ctx.respond(ctx.t("tags.saved", default="Tag `{name}` saved.", name=name), ephemeral=True)
 
     @slash(description="Delete a tag (admin or creator only).", guild_only=True)
     async def delete(self, ctx, name: str) -> None:
         entry = self._store.get(ctx.guild_id, name)
         if entry is None:
-            await ctx.respond(f"Tag `{name}` not found.", ephemeral=True)
+            await ctx.respond(ctx.t("tags.not_found", default="Tag `{name}` not found.", name=name), ephemeral=True)
             return
         member = ctx.guild.get_member(ctx.user.id)
         is_admin = member is not None and member.guild_permissions.administrator
         if ctx.user.id != entry["author_id"] and not is_admin:
             await ctx.respond(
-                "You can only delete your own tags (or be an admin).", ephemeral=True
+                ctx.t("tags.cannot_delete", default="You can only delete your own tags (or be an admin)."),
+                ephemeral=True,
             )
             return
         self._store.delete(ctx.guild_id, name)
-        await ctx.respond(f"Tag `{name}` deleted.", ephemeral=True)
+        await ctx.respond(ctx.t("tags.deleted", default="Tag `{name}` deleted.", name=name), ephemeral=True)
 
     @slash(description="List all tags in this server.", guild_only=True)
     async def list(self, ctx) -> None:
         names = self._store.list_names(ctx.guild_id)
         if not names:
-            await ctx.respond("No tags yet.", ephemeral=True)
+            await ctx.respond(ctx.t("tags.empty", default="No tags yet."), ephemeral=True)
             return
-        await ctx.respond("**Tags:**\n" + "\n".join(names), ephemeral=True)
+        tag_list = ctx.t("tags.header", default="**Tags:**") + "\n" + "\n".join(names)
+        await ctx.respond(tag_list, ephemeral=True)

--- a/tests/test_tags_plugin.py
+++ b/tests/test_tags_plugin.py
@@ -89,6 +89,12 @@ def _make_ctx(guild_id=1, user_id=10, is_admin=False):
     ctx.guild.get_member = MagicMock(return_value=member)
     ctx.user = MagicMock()
     ctx.user.id = user_id
+    # Mock ctx.t() to return the default value
+    def t_mock(key, default=None, **kwargs):
+        if default is not None:
+            return default.format(**kwargs) if kwargs else default
+        return key
+    ctx.t = MagicMock(side_effect=t_mock)
     return ctx
 
 


### PR DESCRIPTION
Localize TagsPlugin responses.

Changes:
- tags.not_found: 'Tag `{name}` not found.'
- tags.saved: 'Tag `{name}` saved.'
- tags.deleted: 'Tag `{name}` deleted.'
- tags.cannot_delete: 'You can only delete your own tags (or be an admin).'
- tags.empty: 'No tags yet.'
- tags.header: '**Tags:**'
- Update tests to mock ctx.t() with default value substitution

Tests: 452 passing
Resolves: #10

## Summary by Sourcery

Localize all user-facing messages in the tags plugin and adjust tests accordingly.

New Features:
- Add i18n support for tag-related user messages using ctx.t() with default fallbacks.

Tests:
- Update tags plugin tests to mock ctx.t() with default value substitution for localized messages.