### PR TITLE
OpenClaude plugin: /ask command for Claude API integration

### DIFF
--- a/easycord/plugins/__init__.py
+++ b/easycord/plugins/__init__.py
@@ -1,7 +1,8 @@
 """Optional first-party plugins."""
 from .levels import LevelsPlugin
+from .openclaude import OpenClaudePlugin
 from .polls import PollsPlugin
 from .tags import TagsPlugin
 from .welcome import WelcomePlugin
 
-__all__ = ["LevelsPlugin", "PollsPlugin", "TagsPlugin", "WelcomePlugin"]
+__all__ = ["LevelsPlugin", "OpenClaudePlugin", "PollsPlugin", "TagsPlugin", "WelcomePlugin"]

--- a/easycord/plugins/openclaude.py
+++ b/easycord/plugins/openclaude.py
@@ -1,0 +1,107 @@
+"""OpenClaude integration for AI-powered responses via Claude."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import discord
+
+from easycord import Plugin, slash
+
+
+class OpenClaudePlugin(Plugin):
+    """AI assistant plugin using Claude API for intelligent responses.
+
+    Members can ask questions via `/ask` and receive Claude-generated responses.
+    Requires ANTHROPIC_API_KEY environment variable or explicit API key.
+
+    Quick start::
+
+        from easycord.plugins.openclaude import OpenClaudePlugin
+        bot.add_plugin(OpenClaudePlugin())
+
+    Slash commands registered
+    -------------------------
+    ``/ask`` — Ask Claude a question and get an AI-powered response.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "claude-3-5-sonnet-20241022") -> None:
+        """Initialize OpenClaude plugin.
+
+        Parameters
+        ----------
+        api_key : str, optional
+            Anthropic API key. If not provided, uses ANTHROPIC_API_KEY env var.
+        model : str
+            Claude model to use (default: claude-3-5-sonnet-20241022).
+        """
+        self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        self._model = model
+        self._client = None
+
+        if not self._api_key:
+            raise ValueError("ANTHROPIC_API_KEY env var or api_key param required")
+
+    def _init_client(self):
+        """Lazy-initialize Anthropic client."""
+        if self._client is None:
+            try:
+                from anthropic import Anthropic
+            except ImportError:
+                raise ImportError("anthropic package required. Install with: pip install anthropic")
+            self._client = Anthropic(api_key=self._api_key)
+
+    @slash(description="Ask Claude a question and get an AI response.", guild_only=True)
+    async def ask(self, ctx, prompt: str) -> None:
+        """Ask Claude a question.
+
+        Parameters
+        ----------
+        ctx : Context
+            Command context.
+        prompt : str
+            Question or prompt for Claude.
+        """
+        await ctx.defer()
+
+        try:
+            self._init_client()
+
+            # Call Claude API
+            message = self._client.messages.create(
+                model=self._model,
+                max_tokens=1024,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt,
+                    }
+                ],
+            )
+
+            # Extract response text
+            response_text = message.content[0].text
+
+            # Send response (truncate if too long)
+            if len(response_text) > 2000:
+                response_text = response_text[:1997] + "..."
+
+            await ctx.respond(response_text)
+
+        except ImportError:
+            await ctx.respond(
+                ctx.t(
+                    "openclaude.anthropic_not_installed",
+                    default="Anthropic SDK not installed. Run: `pip install anthropic`",
+                ),
+                ephemeral=True,
+            )
+        except Exception as exc:
+            await ctx.respond(
+                ctx.t(
+                    "openclaude.error",
+                    default="Error calling Claude: {error}",
+                    error=str(exc),
+                ),
+                ephemeral=True,
+            )

--- a/tests/test_openclaude_plugin.py
+++ b/tests/test_openclaude_plugin.py
@@ -1,0 +1,109 @@
+"""Tests for easycord.plugins.openclaude — OpenClaudePlugin."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from easycord.plugins.openclaude import OpenClaudePlugin
+
+
+def test_init_requires_api_key():
+    """Plugin requires ANTHROPIC_API_KEY or api_key param."""
+    with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+        OpenClaudePlugin(api_key=None)
+
+
+def test_init_with_api_key():
+    """Plugin initializes with explicit API key."""
+    plugin = OpenClaudePlugin(api_key="test-key")
+    assert plugin._api_key == "test-key"
+
+
+def test_init_with_env_var(monkeypatch):
+    """Plugin reads ANTHROPIC_API_KEY from environment."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
+    plugin = OpenClaudePlugin()
+    assert plugin._api_key == "env-key"
+
+
+def test_model_customizable():
+    """Plugin accepts custom model."""
+    plugin = OpenClaudePlugin(api_key="test", model="claude-3-opus")
+    assert plugin._model == "claude-3-opus"
+
+
+@pytest.mark.asyncio
+async def test_ask_command_defers_response():
+    """Ask command defers response while calling API."""
+    plugin = OpenClaudePlugin(api_key="test-key")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+
+    with patch.object(plugin, "_init_client"):
+        with patch.object(plugin, "_client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.content = [MagicMock(text="Test response")]
+            mock_client.messages.create.return_value = mock_response
+
+            await plugin.ask(ctx, prompt="Test prompt")
+
+            ctx.defer.assert_called_once()
+            ctx.respond.assert_called_once_with("Test response")
+
+
+@pytest.mark.asyncio
+async def test_ask_command_truncates_long_responses():
+    """Ask command truncates responses over 2000 chars."""
+    plugin = OpenClaudePlugin(api_key="test-key")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+
+    long_text = "x" * 3000
+    with patch.object(plugin, "_init_client"):
+        with patch.object(plugin, "_client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.content = [MagicMock(text=long_text)]
+            mock_client.messages.create.return_value = mock_response
+
+            await plugin.ask(ctx, prompt="Test")
+
+            called_text = ctx.respond.call_args[0][0]
+            assert len(called_text) <= 2000
+            assert called_text.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_ask_command_handles_missing_sdk():
+    """Ask command gracefully handles missing Anthropic SDK."""
+    plugin = OpenClaudePlugin(api_key="test-key")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.t = MagicMock(return_value="SDK not installed")
+    ctx.respond = AsyncMock()
+
+    with patch.object(plugin, "_init_client", side_effect=ImportError("anthropic")):
+        await plugin.ask(ctx, prompt="Test")
+
+        ctx.respond.assert_called_once()
+        call_args = ctx.respond.call_args
+        assert "not installed" in call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_ask_command_handles_api_errors():
+    """Ask command handles API errors gracefully."""
+    plugin = OpenClaudePlugin(api_key="test-key")
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.t = MagicMock(return_value="API error")
+    ctx.respond = AsyncMock()
+
+    with patch.object(plugin, "_init_client"):
+        with patch.object(plugin, "_client") as mock_client:
+            mock_client.messages.create.side_effect = Exception("Rate limit exceeded")
+
+            await plugin.ask(ctx, prompt="Test")
+
+            ctx.respond.assert_called_once()
+            call_args = ctx.respond.call_args
+            assert "error" in call_args[0][0].lower() or "Rate limit" in call_args[0][0]


### PR DESCRIPTION
## Summary

Implement OpenClaudePlugin with /ask slash command for querying Claude API via Anthropic SDK.

## Changes

- **easycord/plugins/openclaude.py** — New plugin class with:
  - Lazy-initialized Anthropic client
  - /ask slash command accepting user prompt
  - Deferred response handling for long API calls
  - Response truncation at 2000 chars (Discord msg limit)
  - Error handling: ImportError (missing SDK), API errors
  - Localization support (openclaude.anthropic_not_installed, openclaude.error)
  - Configurable API key (param or ANTHROPIC_API_KEY env var)
  - Customizable model selection

- **easycord/plugins/__init__.py** — Export OpenClaudePlugin

- **tests/test_openclaude_plugin.py** — 8 test cases:
  - API key requirement validation
  - Model customization
  - Command deferral and response flow
  - Response truncation
  - Missing Anthropic SDK handling
  - API error handling

## Test Results

- All 8 new tests passing
- Full test suite: 460/460 passing (no regressions)

## Notes

MVP implementation focuses on basic /ask command. Future expansions:
- Streaming responses
- Context memory across messages
- Advanced rate limiting
- Enhanced error recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new OpenClaude plugin that integrates the Anthropic Claude API into EasyCord via a /ask slash command.

New Features:
- Introduce OpenClaudePlugin providing an /ask slash command to query Anthropic's Claude models from Discord.
- Allow configuration of Anthropic API key via constructor or ANTHROPIC_API_KEY environment variable and selection of Claude model.

Enhancements:
- Export OpenClaudePlugin from the plugins package for easy use by bots.

Tests:
- Add unit tests covering OpenClaudePlugin initialization, API key and model configuration, slash command behavior, response truncation, and error handling for missing SDK and API failures.