### PR TITLE
Add issue auto-fix workflow and AI helper fixes

### DIFF
--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -1,0 +1,100 @@
+name: Auto-fix Issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Branch to check out, fix, validate, and push"
+        required: true
+        default: "main"
+      fix_command:
+        description: "Command that applies repository fixes before validation"
+        required: true
+        default: "python scripts/fix_issues.py"
+      commit_message:
+        description: "Commit message for pushed fixes"
+        required: true
+        default: "chore: auto-fix issue triage"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  auto-fix:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.comment.body, '/fix-issues')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve target branch
+        id: target
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === "workflow_dispatch") {
+              core.setOutput("branch", core.getInput("target_branch"));
+              core.setOutput("fix_command", core.getInput("fix_command"));
+              core.setOutput("commit_message", core.getInput("commit_message"));
+              return;
+            }
+
+            const issue = context.payload.issue;
+            if (!issue.pull_request) {
+              core.setFailed("/fix-issues comments are only supported on pull requests.");
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issue.number,
+            });
+
+            if (pull.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed("Auto-fix can only push to branches in this repository.");
+              return;
+            }
+
+            core.setOutput("branch", pull.head.ref);
+            core.setOutput("fix_command", "python scripts/fix_issues.py");
+            core.setOutput("commit_message", `chore: auto-fix PR #${issue.number} issue triage`);
+
+      - name: Check out target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install project and build tools
+        run: python -m pip install --upgrade pip build && python -m pip install -e ".[dev]"
+
+      - name: Apply fixes
+        run: ${{ steps.target.outputs.fix_command }}
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Build package
+        run: python -m build
+
+      - name: Commit and push fixes
+        shell: bash
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No fixes produced."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "${{ steps.target.outputs.commit_message }}"
+          git push origin "HEAD:${{ steps.target.outputs.branch }}"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,20 @@ bot.add_plugin(OpenClaudePlugin(api_key="sk-ant-..."))  # or ANTHROPIC_API_KEY e
 bot.run("YOUR_TOKEN")
 ```
 
-Members use `/ask "your question"` to query Claude API. Responses are automatically truncated to Discord's 2000-char limit.
+Members use `/ask "your question"` to query Claude API. Responses are automatically truncated to Discord's 2000-char limit, requests are rate limited per user, and the waiting message can be localized with `openclaude.thinking`.
+
+For custom commands, configure a shared provider and call it through context:
+
+```python
+from easycord.plugins import OpenAIProvider
+
+bot = Bot(ai_provider=OpenAIProvider(api_key="sk-..."))
+
+@bot.slash(description="Ask AI")
+async def ask(ctx, prompt: str):
+    response = await ctx.ai(prompt, model="gpt-4o")
+    await ctx.respond(response[:2000])
+```
 
 **Setup:** Install `anthropic` SDK and set `ANTHROPIC_API_KEY` environment variable.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@ If you are learning the framework for the first time, these are the main buildin
 | Save guild settings | `ServerConfigStore` |
 | Load bundled plugins | `bot.load_builtin_plugins()` |
 | Store guild data | `bot.db` |
+| Query an AI provider | `await ctx.ai(...)` |
 
 ```python
 from easycord import Bot
@@ -30,7 +31,7 @@ need, then register a few slash commands on top.
 
 ## `easycord.Bot`
 
-`Bot(*, intents=None, auto_sync=True, load_builtin_plugins=False, database=None, db_backend=None, db_path=None, db_auto_sync_guilds=None, **kwargs)`
+`Bot(*, intents=None, auto_sync=True, load_builtin_plugins=False, database=None, db_backend=None, db_path=None, db_auto_sync_guilds=None, ai_provider=None, **kwargs)`
 
 `bot.db` is auto-configured if you do not pass a database object. The default
 backend is SQLite and the default path is `.easycord/library.db`. You can
@@ -171,6 +172,8 @@ Middleware runs on component interactions exactly as it does for slash commands.
 `await ctx.respond(content=None, *, ephemeral=False, embed=None, **kwargs)` — first call: `send_message`; subsequent: `followup.send`
 
 `await ctx.defer(*, ephemeral=False)` — acknowledge without visible reply; use before slow operations
+
+`await ctx.ai(prompt, *, provider=None, model=None)` — query the configured AI provider and return response text. Configure `Bot(ai_provider=provider)` for a shared provider, or pass `provider=...` for a one-off request. `model=...` temporarily overrides providers that expose `_model`.
 
 `await ctx.send_embed(title, description=None, *, fields=None, footer=None, thumbnail=None, image=None, author=None, timestamp=None, color=blue, ephemeral=False)` — fields: `[(name, value)]` or `[(name, value, inline)]`; `thumbnail`/`image`: URL strings; `author`: name string or `{"name", "icon_url", "url"}` dict; `timestamp=True` uses current UTC time
 
@@ -651,6 +654,30 @@ Create and manage server invites:
 ---
 
 ## AI & Orchestration
+
+### `ctx.ai(...)`
+
+Use a shared provider for small custom AI commands without adding a full plugin:
+
+```python
+from easycord import Bot
+from easycord.plugins import OpenAIProvider
+
+provider = OpenAIProvider(api_key="sk-...")
+bot = Bot(ai_provider=provider)
+
+@bot.slash(description="Ask AI")
+async def ask(ctx, prompt: str):
+    response = await ctx.ai(prompt, model="gpt-4o")
+    await ctx.respond(response[:2000])
+```
+
+### `AIPlugin` / `OpenClaudePlugin`
+
+`AIPlugin(provider, *, rate_limit=3, rate_window=60.0)` registers `/ask` for any provider.
+`OpenClaudePlugin(api_key=None, model="claude-3-5-sonnet-20241022", rate_limit=3, rate_window=60.0)` keeps the Claude shortcut.
+
+`OpenClaudePlugin` sends `openclaude.thinking` through `ctx.t(...)` before calling the provider, then edits that message with the final response. `AIPlugin` and `OpenClaudePlugin` both enforce the per-user, per-guild request limit and use `ai.rate_limited` for localized cooldown text.
 
 ### `Orchestrator`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,7 +64,7 @@ bot.add_plugin(OpenClaudePlugin(api_key="sk-ant-..."))
 bot.run("YOUR_DISCORD_TOKEN")
 ```
 
-Members use `/ask "your question"` to query Claude.
+Members use `/ask "your question"` to query Claude. The command is rate limited per user by default, shows a localized `openclaude.thinking` message while waiting, and edits that message with the final response.
 
 ### With OpenAI (ChatGPT/GPT-4)
 
@@ -77,6 +77,21 @@ provider = OpenAIProvider(api_key="sk-...")  # or OPENAI_API_KEY env var
 bot.add_plugin(AIPlugin(provider=provider))
 
 bot.run("YOUR_DISCORD_TOKEN")
+```
+
+### With `ctx.ai(...)`
+
+```python
+from easycord import Bot
+from easycord.plugins import OpenAIProvider
+
+provider = OpenAIProvider(api_key="sk-...")
+bot = Bot(ai_provider=provider)
+
+@bot.slash(description="Ask AI")
+async def ask(ctx, prompt: str):
+    response = await ctx.ai(prompt, model="gpt-4o")
+    await ctx.respond(response[:2000])
 ```
 
 ### With Google Gemini

--- a/easycord/_context_base.py
+++ b/easycord/_context_base.py
@@ -1,6 +1,8 @@
 """Core Context object wrapping discord.Interaction with a simple response API."""
 from __future__ import annotations
 
+import asyncio
+
 import discord
 
 from .i18n import LocalizationManager
@@ -131,6 +133,32 @@ class BaseContext:
             return
         self._responded = True
         await self.interaction.response.defer(ephemeral=ephemeral)
+
+    async def ai(self, prompt: str, *, provider=None, model: str | None = None) -> str:
+        """Query the configured AI provider and return response text.
+
+        Pass ``provider=...`` for one-off calls, or configure ``Bot(ai_provider=...)``
+        so commands can call ``await ctx.ai("...")`` directly.
+        """
+        provider = provider or getattr(self.interaction.client, "ai_provider", None)
+        if provider is None:
+            raise RuntimeError("No AI provider configured. Pass provider=... or set Bot(ai_provider=...).")
+
+        old_model = getattr(provider, "_model", None)
+        should_restore = model is not None and hasattr(provider, "_model")
+        if not should_restore:
+            return await provider.query(prompt)
+
+        lock = getattr(provider, "_easycord_model_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            provider._easycord_model_lock = lock
+        async with lock:
+            provider._model = model
+            try:
+                return await provider.query(prompt)
+            finally:
+                provider._model = old_model
 
     async def send_embed(
         self,

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -69,6 +69,7 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
         default_locale: str = "en-US",
         translations: dict | None = None,
         auto_translator: Callable[[str, str, str], str | None] | None = None,
+        ai_provider=None,
         **kwargs,
     ) -> None:
         super().__init__(intents=intents or discord.Intents.default(), **kwargs)
@@ -80,6 +81,7 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
         self._task_handles: dict[int, list[asyncio.Task]] = {}
         self._webhooks: dict[int, discord.Webhook] = {}
         self.registry = InteractionRegistry()
+        self.ai_provider = ai_provider
         self.ai_tools: dict[str, dict] = {}
         self.tool_registry = ToolRegistry()
         try:

--- a/easycord/plugins/levels.py
+++ b/easycord/plugins/levels.py
@@ -165,7 +165,7 @@ class LevelsPlugin(Plugin):
 
     @on("message")
     async def _award_xp(self, message: discord.Message) -> None:
-        if getattr(message.author, "bot", False) is True or not message.guild:
+        if getattr(message.author, "bot", False) is True or message.guild is None:
             return
 
         guild_id = message.guild.id

--- a/easycord/plugins/levels.py
+++ b/easycord/plugins/levels.py
@@ -165,7 +165,7 @@ class LevelsPlugin(Plugin):
 
     @on("message")
     async def _award_xp(self, message: discord.Message) -> None:
-        if message.author.bot or not message.guild:
+        if getattr(message.author, "bot", False) is True or not message.guild:
             return
 
         guild_id = message.guild.id

--- a/easycord/plugins/openclaude.py
+++ b/easycord/plugins/openclaude.py
@@ -1,6 +1,7 @@
 """AI assistant plugins using various LLM provider APIs."""
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Optional
 
 from easycord import Plugin, slash
@@ -28,7 +29,14 @@ class AIPlugin(Plugin):
     ``/ask`` — Ask the AI a question and get a response.
     """
 
-    def __init__(self, provider: AIProvider) -> None:
+    def __init__(
+        self,
+        provider: AIProvider,
+        *,
+        rate_limit: int = 3,
+        rate_window: float = 60.0,
+        thinking_key: str | None = None,
+    ) -> None:
         """Initialize AI plugin.
 
         Parameters
@@ -38,6 +46,10 @@ class AIPlugin(Plugin):
         """
         super().__init__()
         self._provider = provider
+        self._rate_limit = rate_limit
+        self._rate_window = rate_window
+        self._thinking_key = thinking_key
+        self._requests: dict[tuple[int | None, int], list[float]] = {}
 
     @staticmethod
     def _format_response(text: str) -> str:
@@ -45,6 +57,26 @@ class AIPlugin(Plugin):
         if len(text) > 2000:
             return text[:1997] + "..."
         return text
+
+    def _rate_limit_retry_after(self, ctx) -> float | None:
+        if self._rate_limit <= 0:
+            return None
+
+        guild_id = getattr(ctx, "guild_id", None)
+        user_id = getattr(getattr(ctx, "user", None), "id", None)
+        if user_id is None:
+            return None
+
+        now = time.monotonic()
+        key = (guild_id, int(user_id))
+        window_start = now - self._rate_window
+        entries = [stamp for stamp in self._requests.get(key, []) if stamp > window_start]
+        if len(entries) >= self._rate_limit:
+            self._requests[key] = entries
+            return max(0.0, self._rate_window - (now - entries[0]))
+        entries.append(now)
+        self._requests[key] = entries
+        return None
 
     @slash(description="Ask an AI a question and get a response.", guild_only=True)
     async def ask(self, ctx, prompt: str) -> None:
@@ -57,11 +89,32 @@ class AIPlugin(Plugin):
         prompt : str
             Question or prompt for the AI.
         """
-        await ctx.defer()
+        retry_after = self._rate_limit_retry_after(ctx)
+        if retry_after is not None:
+            await ctx.respond(
+                ctx.t(
+                    "ai.rate_limited",
+                    default="You're asking too quickly. Try again in {seconds:.0f}s.",
+                    seconds=retry_after,
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if self._thinking_key:
+            await ctx.respond(
+                ctx.t(self._thinking_key, default="Thinking..."),
+            )
+        else:
+            await ctx.defer()
 
         try:
             response_text = await self._provider.query(prompt)
-            await ctx.respond(self._format_response(response_text))
+            response = self._format_response(response_text)
+            if self._thinking_key:
+                await ctx.edit_response(response)
+            else:
+                await ctx.respond(response)
 
         except ImportError as exc:
             await ctx.respond(
@@ -104,6 +157,8 @@ class OpenClaudePlugin(AIPlugin):
         self,
         api_key: Optional[str] = None,
         model: str = "claude-3-5-sonnet-20241022",
+        rate_limit: int = 3,
+        rate_window: float = 60.0,
     ) -> None:
         """Initialize OpenClaude plugin.
 
@@ -117,4 +172,9 @@ class OpenClaudePlugin(AIPlugin):
         from ._ai_providers import AnthropicProvider
 
         provider = AnthropicProvider(api_key=api_key, model=model)
-        super().__init__(provider=provider)
+        super().__init__(
+            provider=provider,
+            rate_limit=rate_limit,
+            rate_window=rate_window,
+            thinking_key="openclaude.thinking",
+        )

--- a/scripts/fix_issues.py
+++ b/scripts/fix_issues.py
@@ -1,0 +1,14 @@
+"""Repository hook for the Auto-fix Issues workflow.
+
+Keep this script deterministic: it should apply mechanical fixes that are safe
+to run in CI, then leave semantic changes to normal pull requests.
+"""
+from __future__ import annotations
+
+
+def main() -> None:
+    print("No repository-local mechanical issue fixes are configured.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -26,6 +26,15 @@ def test_use_returns_middleware(bot):
     assert result is mw
 
 
+def test_bot_stores_ai_provider():
+    from easycord import Bot
+
+    provider = object()
+    bot = Bot(ai_provider=provider)
+
+    assert bot.ai_provider is provider
+
+
 def test_multiple_middleware_preserved_in_order(bot):
     async def mw1(ctx, _proceed): pass
     async def mw2(ctx, _proceed): pass

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -135,6 +135,38 @@ async def test_defer_then_respond_uses_followup(ctx, interaction):
     interaction.followup.send.assert_called_once()
 
 
+async def test_ai_uses_configured_bot_provider(ctx, interaction):
+    provider = MagicMock()
+    provider.query = AsyncMock(return_value="AI response")
+    interaction.client.ai_provider = provider
+
+    assert await ctx.ai("hello") == "AI response"
+    provider.query.assert_called_once_with("hello")
+
+
+async def test_ai_accepts_one_off_provider(ctx):
+    provider = MagicMock()
+    provider.query = AsyncMock(return_value="One-off response")
+
+    assert await ctx.ai("hello", provider=provider) == "One-off response"
+
+
+async def test_ai_temporarily_overrides_model(ctx):
+    provider = MagicMock()
+    provider._model = "default"
+    provider.query = AsyncMock(return_value="Model response")
+
+    assert await ctx.ai("hello", provider=provider, model="custom") == "Model response"
+    assert provider._model == "default"
+
+
+async def test_ai_requires_provider(ctx, interaction):
+    interaction.client.ai_provider = None
+
+    with pytest.raises(RuntimeError, match="No AI provider configured"):
+        await ctx.ai("hello")
+
+
 # --- send_embed ---
 
 async def test_send_embed_sends_embed(ctx, interaction):

--- a/tests/test_openclaude_plugin.py
+++ b/tests/test_openclaude_plugin.py
@@ -377,6 +377,8 @@ async def test_aiplugin_ask_calls_provider_and_responds():
     ctx = MagicMock()
     ctx.defer = AsyncMock()
     ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
 
     await plugin.ask(ctx, prompt="test")
 
@@ -393,6 +395,8 @@ async def test_aiplugin_truncates_long_response():
     ctx = MagicMock()
     ctx.defer = AsyncMock()
     ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
 
     await plugin.ask(ctx, prompt="test")
 
@@ -411,6 +415,8 @@ async def test_aiplugin_handles_import_error():
     ctx.defer = AsyncMock()
     ctx.t = MagicMock(return_value="sdk missing")
     ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
 
     await plugin.ask(ctx, prompt="test")
 
@@ -428,6 +434,8 @@ async def test_aiplugin_handles_api_error():
     ctx.defer = AsyncMock()
     ctx.t = MagicMock(return_value="Error calling AI: rate limit exceeded")
     ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
 
     await plugin.ask(ctx, prompt="test")
 
@@ -467,14 +475,69 @@ def test_openclaude_model_customizable():
 
 @pytest.mark.asyncio
 async def test_openclaude_ask_defers_and_responds():
-    """OpenClaudePlugin.ask defers and responds."""
+    """OpenClaudePlugin.ask shows a localized thinking message and edits it."""
     plugin = OpenClaudePlugin(api_key="test-key")
     ctx = MagicMock()
     ctx.defer = AsyncMock()
+    ctx.t = MagicMock(return_value="Thinking locally...")
     ctx.respond = AsyncMock()
+    ctx.edit_response = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
 
     with patch.object(plugin._provider, "query", new_callable=AsyncMock, return_value="Test response"):
         await plugin.ask(ctx, prompt="Test prompt")
 
-    ctx.defer.assert_called_once()
-    ctx.respond.assert_called_once_with("Test response")
+    ctx.defer.assert_not_called()
+    ctx.t.assert_called_once_with("openclaude.thinking", default="Thinking...")
+    ctx.respond.assert_called_once_with("Thinking locally...")
+    ctx.edit_response.assert_called_once_with("Test response")
+
+
+@pytest.mark.asyncio
+async def test_aiplugin_rate_limits_per_user():
+    """AIPlugin.ask rate limits repeated requests per guild/user."""
+    provider = MagicMock(spec=AIProvider)
+    provider.query = AsyncMock(return_value="AI response")
+    plugin = AIPlugin(provider=provider, rate_limit=1, rate_window=60)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+    ctx.t = MagicMock(return_value="Slow down")
+    ctx.user.id = 123
+    ctx.guild_id = 456
+
+    await plugin.ask(ctx, prompt="first")
+    await plugin.ask(ctx, prompt="second")
+
+    assert provider.query.await_count == 1
+    ctx.t.assert_called_with(
+        "ai.rate_limited",
+        default="You're asking too quickly. Try again in {seconds:.0f}s.",
+        seconds=pytest.approx(60, abs=1),
+    )
+    assert ctx.respond.call_args_list[-1].kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_aiplugin_rate_limit_is_per_user():
+    """AIPlugin.ask tracks separate users independently."""
+    provider = MagicMock(spec=AIProvider)
+    provider.query = AsyncMock(return_value="AI response")
+    plugin = AIPlugin(provider=provider, rate_limit=1, rate_window=60)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
+
+    other_ctx = MagicMock()
+    other_ctx.defer = AsyncMock()
+    other_ctx.respond = AsyncMock()
+    other_ctx.user.id = 999
+    other_ctx.guild_id = 456
+
+    await plugin.ask(ctx, prompt="first")
+    await plugin.ask(other_ctx, prompt="second")
+
+    assert provider.query.await_count == 2


### PR DESCRIPTION
## Summary
- add an Auto-fix Issues workflow that can be manually dispatched or triggered with `/fix-issues` on in-repo PRs, validates fixes, and pushes generated commits back to the target branch
- add `Bot(ai_provider=...)` and `await ctx.ai(...)` for a shared or one-off AI provider entry point
- add per-user, per-guild rate limiting to `AIPlugin` / `OpenClaudePlugin`
- make `OpenClaudePlugin` send localized `openclaude.thinking` text before editing the response with the final answer
- document the new AI helper, rate limiting, and localized thinking behavior

## Issues / PR triage covered
- #20: per-user `/ask` rate limiting with test coverage
- #21: localized OpenClaude thinking message before response edit
- #22: `ctx.ai()` helper with shared provider wiring and focused tests
- #24: helper work represented by the new context AI helper and workflow hook
- #25: left as broader architecture/documentation platform work; current `main` already contains the larger stability/scope docs
- #27: PR is docs-only and redundant with current `main`'s performance documentation, so this PR does not reapply the conflicting doc branch
- #5: obsolete/conflicting release PR; this branch is based on current `main` instead

## Validation
- `pytest` (`589 passed`)
- `python -m compileall easycord examples docs tests scripts`
- `python -m build`

## Summary by Sourcery

Add a configurable AI helper entry point, rate-limited AI plugins with localized thinking messages, and an automated workflow for mechanically fixing issues and validating changes.

New Features:
- Introduce a shared `ai_provider` on `Bot` and a `ctx.ai(...)` helper for querying AI providers from commands.
- Add a GitHub Actions `Auto-fix Issues` workflow and `scripts/fix_issues.py` hook to apply mechanical fixes, run tests, build the package, and push commits.
- Extend `AIPlugin` and `OpenClaudePlugin` with configurable rate limiting and localized thinking message support for `/ask`.

Enhancements:
- Make `OpenClaudePlugin` send a localized `openclaude.thinking` message before editing it with the final AI response.
- Add per-user, per-guild rate limiting to `AIPlugin` and `OpenClaudePlugin`, returning localized cooldown messages when limits are hit.

CI:
- Add an auto-fix workflow that can be dispatch-triggered or invoked via `/fix-issues` comments on in-repo pull requests, enforcing tests and build before pushing fixes.

Documentation:
- Document the new `ctx.ai(...)` helper, `Bot(ai_provider=...)` configuration, AI plugin rate limiting, and localized OpenClaude thinking behavior in API docs, examples, and README.

Tests:
- Add tests for the new `ctx.ai(...)` helper behaviors and storage of `ai_provider` on `Bot`.
- Extend AI plugin tests to cover per-user rate limiting, localized thinking messages, and required context identifiers for rate tracking.