### PR TITLE
harden auto-fix workflow and AI plugin limits

### DIFF
--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -35,8 +35,17 @@ jobs:
         with:
           script: |
             if (context.eventName === "workflow_dispatch") {
-              core.setOutput("branch", core.getInput("target_branch"));
-              core.setOutput("fix_command", core.getInput("fix_command"));
+              const inputBranch = core.getInput("target_branch");
+              const inputCommand = core.getInput("fix_command");
+
+              // Keep command execution constrained to a known safe prefix.
+              if (!/^python\s+scripts\/[A-Za-z0-9._/-]+\.py(?:\s+.*)?$/.test(inputCommand)) {
+                core.setFailed("fix_command must start with `python scripts/<name>.py`.");
+                return;
+              }
+
+              core.setOutput("branch", inputBranch);
+              core.setOutput("fix_command", inputCommand);
               core.setOutput("commit_message", core.getInput("commit_message"));
               return;
             }
@@ -55,6 +64,18 @@ jobs:
 
             if (pull.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
               core.setFailed("Auto-fix can only push to branches in this repository.");
+              return;
+            }
+
+            const commenter = context.payload.comment.user.login;
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: commenter,
+            });
+            const allowed = new Set(["admin", "maintain", "write"]);
+            if (!allowed.has(permission.permission)) {
+              core.setFailed("Only repository writers can trigger /fix-issues.");
               return;
             }
 

--- a/easycord/plugins/openclaude.py
+++ b/easycord/plugins/openclaude.py
@@ -36,6 +36,7 @@ class AIPlugin(Plugin):
         rate_limit: int = 3,
         rate_window: float = 60.0,
         thinking_key: str | None = None,
+        max_prompt_chars: int = 4000,
     ) -> None:
         """Initialize AI plugin.
 
@@ -49,6 +50,7 @@ class AIPlugin(Plugin):
         self._rate_limit = rate_limit
         self._rate_window = rate_window
         self._thinking_key = thinking_key
+        self._max_prompt_chars = max_prompt_chars
         self._requests: dict[tuple[int | None, int], list[float]] = {}
 
     @staticmethod
@@ -78,6 +80,17 @@ class AIPlugin(Plugin):
         self._requests[key] = entries
         return None
 
+    def _prune_old_request_buckets(self, now: float) -> None:
+        # Keep the in-memory limiter bounded over long uptimes.
+        stale_before = now - self._rate_window
+        stale_keys = [
+            key
+            for key, values in self._requests.items()
+            if not any(stamp > stale_before for stamp in values)
+        ]
+        for key in stale_keys:
+            del self._requests[key]
+
     @slash(description="Ask an AI a question and get a response.", guild_only=True)
     async def ask(self, ctx, prompt: str) -> None:
         """Ask AI a question.
@@ -89,6 +102,18 @@ class AIPlugin(Plugin):
         prompt : str
             Question or prompt for the AI.
         """
+        if self._max_prompt_chars > 0 and len(prompt) > self._max_prompt_chars:
+            await ctx.respond(
+                ctx.t(
+                    "ai.prompt_too_long",
+                    default="Prompt is too long. Maximum length is {limit} characters.",
+                    limit=self._max_prompt_chars,
+                ),
+                ephemeral=True,
+            )
+            return
+
+        self._prune_old_request_buckets(time.monotonic())
         retry_after = self._rate_limit_retry_after(ctx)
         if retry_after is not None:
             await ctx.respond(
@@ -159,6 +184,7 @@ class OpenClaudePlugin(AIPlugin):
         model: str = "claude-3-5-sonnet-20241022",
         rate_limit: int = 3,
         rate_window: float = 60.0,
+        max_prompt_chars: int = 4000,
     ) -> None:
         """Initialize OpenClaude plugin.
 
@@ -177,4 +203,5 @@ class OpenClaudePlugin(AIPlugin):
             rate_limit=rate_limit,
             rate_window=rate_window,
             thinking_key="openclaude.thinking",
+            max_prompt_chars=max_prompt_chars,
         )

--- a/tests/test_openclaude_plugin.py
+++ b/tests/test_openclaude_plugin.py
@@ -541,3 +541,43 @@ async def test_aiplugin_rate_limit_is_per_user():
     await plugin.ask(other_ctx, prompt="second")
 
     assert provider.query.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_aiplugin_rejects_overlong_prompt():
+    """AIPlugin.ask rejects prompts that exceed configured max length."""
+    provider = MagicMock(spec=AIProvider)
+    provider.query = AsyncMock(return_value="AI response")
+    plugin = AIPlugin(provider=provider, max_prompt_chars=5)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+    ctx.t = MagicMock(return_value="Too long")
+    ctx.user.id = 123
+    ctx.guild_id = 456
+
+    await plugin.ask(ctx, prompt="this prompt is too long")
+
+    provider.query.assert_not_awaited()
+    ctx.respond.assert_called_once()
+    assert ctx.respond.call_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_aiplugin_prunes_stale_request_buckets():
+    """AIPlugin limiter should prune stale user buckets over time."""
+    provider = MagicMock(spec=AIProvider)
+    provider.query = AsyncMock(return_value="AI response")
+    plugin = AIPlugin(provider=provider, rate_limit=1, rate_window=10)
+    ctx = MagicMock()
+    ctx.defer = AsyncMock()
+    ctx.respond = AsyncMock()
+    ctx.user.id = 123
+    ctx.guild_id = 456
+
+    plugin._requests[(999, 999)] = [0.0]
+    plugin._requests[(456, 123)] = [95.0]
+    with patch("easycord.plugins.openclaude.time.monotonic", return_value=100.0):
+        await plugin.ask(ctx, prompt="ok")
+
+    assert (999, 999) not in plugin._requests


### PR DESCRIPTION
## Summary by Sourcery

Harden the AI plugin rate limiting and prompt handling while tightening security around the auto-fix GitHub workflow.

New Features:
- Add configurable maximum prompt length to the AI plugin and its OpenClaude wrapper, rejecting overlong prompts with a user-facing message.

Enhancements:
- Prune stale entries from the in-memory AI rate-limiter to keep its request bucket map bounded over time.

CI:
- Constrain the auto-fix workflow to only execute fix commands matching a safe `python scripts/<name>.py` pattern.
- Require repository write-level permissions for users triggering the `/fix-issues` command via issue comments.

Tests:
- Add tests verifying the AI plugin rejects prompts exceeding the configured maximum length.
- Add tests ensuring stale rate-limit buckets are pruned as time advances.