### PR TITLE
Automated fix: address CodeRabbit CHANGES_REQUESTED on PR #41 (economy atomicity + test safety)

### DIFF
--- a/easycord/plugins/economy.py
+++ b/easycord/plugins/economy.py
@@ -148,33 +148,26 @@ class EconomyPlugin(Plugin):
     ) -> tuple[bool, int]:
         """Atomically transfer *amount* from sender to receiver.
 
-        Both legs happen under a single lock acquisition so no concurrent
-        path can interleave. If an exception occurs after debiting the sender
-        but before crediting the receiver, the debit is rolled back to avoid
-        losing currency.
+        Reads the config once, computes both new balances in memory, and
+        persists them in a single save under the per-guild lock.  No
+        half-applied state is possible on disk: if the save raises, neither
+        balance has changed.
 
         Returns ``(success, sender_balance_after)``.
         """
         async with self._balance_lock(guild_id):
-            sender_balance = await self._get_balance(guild_id, sender_id)
+            cfg_obj = await self.config.store.load(guild_id)
+            balances = cfg_obj.get_other("balances", {})
+
+            sender_balance = balances.get(str(sender_id), 0)
             if sender_balance < amount:
                 return False, sender_balance
 
-            # Debit sender first
-            await self._set_balance(guild_id, sender_id, sender_balance - amount)
-            try:
-                # Credit receiver
-                receiver_balance = await self._get_balance(guild_id, receiver_id)
-                await self._set_balance(guild_id, receiver_id, receiver_balance + amount)
-            except Exception:
-                # Roll back the debit to avoid losing currency
-                logger.exception(
-                    "Failed to credit receiver %s in guild %s; rolling back debit",
-                    receiver_id,
-                    guild_id,
-                )
-                await self._set_balance(guild_id, sender_id, sender_balance)
-                raise
+            receiver_balance = balances.get(str(receiver_id), 0)
+            balances[str(sender_id)] = max(0, sender_balance - amount)
+            balances[str(receiver_id)] = max(0, receiver_balance + amount)
+            cfg_obj.set_other("balances", balances)
+            await self.config.store.save(cfg_obj)
 
             return True, sender_balance - amount
 
@@ -227,35 +220,42 @@ class EconomyPlugin(Plugin):
 
         The claimed-check, balance award, and claim-mark all happen under a
         single lock and a single config save operation to prevent partial persistence.
+        All I/O to Discord (ctx.respond) happens after releasing the lock.
         """
+        already_claimed = False
+        reward = symbol = currency = new_balance = None
+
         async with self._balance_lock(ctx.guild.id):
             cfg_obj = await self.config.store.load(ctx.guild.id)
-            
+
             daily_claims = cfg_obj.get_other("daily_claims", {})
             today = datetime.now(timezone.utc).date().isoformat()
-            
+
             if daily_claims.get(str(ctx.user.id)) == today:
-                await ctx.respond(
-                    "⏰ You already claimed today's reward. Try again tomorrow!",
-                    ephemeral=True,
-                )
-                return
+                already_claimed = True
+            else:
+                cfg = cfg_obj.get_other("economy") or _DEFAULTS
+                reward = cfg.get("daily_reward", 100)
+                currency = cfg.get("currency_name", "Credits")
+                symbol = cfg.get("currency_symbol", "💰")
 
-            cfg = cfg_obj.get_other("economy") or _DEFAULTS
-            reward = cfg.get("daily_reward", 100)
-            currency = cfg.get("currency_name", "Credits")
-            symbol = cfg.get("currency_symbol", "💰")
+                balances = cfg_obj.get_other("balances", {})
+                current = balances.get(str(ctx.user.id), 0)
+                new_balance = current + reward
+                balances[str(ctx.user.id)] = new_balance
 
-            balances = cfg_obj.get_other("balances", {})
-            current = balances.get(str(ctx.user.id), 0)
-            new_balance = current + reward
-            balances[str(ctx.user.id)] = new_balance
-            
-            daily_claims[str(ctx.user.id)] = today
-            
-            cfg_obj.set_other("balances", balances)
-            cfg_obj.set_other("daily_claims", daily_claims)
-            await self.config.store.save(cfg_obj)
+                daily_claims[str(ctx.user.id)] = today
+
+                cfg_obj.set_other("balances", balances)
+                cfg_obj.set_other("daily_claims", daily_claims)
+                await self.config.store.save(cfg_obj)
+
+        if already_claimed:
+            await ctx.respond(
+                "⏰ You already claimed today's reward. Try again tomorrow!",
+                ephemeral=True,
+            )
+            return
 
         await ctx.respond(f"{symbol} Claimed **{reward}** {currency}! New balance: **{new_balance}**")
 

--- a/tests/test_plugin_logic.py
+++ b/tests/test_plugin_logic.py
@@ -294,29 +294,24 @@ class TestEconomyConcurrency:
         )
 
     @pytest.mark.asyncio
-    async def test_transfer_rollback_on_credit_failure(self, plugin) -> None:
-        """If crediting the receiver fails, the sender's debit must be rolled back."""
-        # Give sender exactly 100 to transfer
+    async def test_transfer_atomic_on_save_failure(self, plugin) -> None:
+        """If the config save fails mid-transfer, neither balance changes."""
         await plugin._set_balance(100, 1, 100)
         await plugin._set_balance(100, 2, 50)
 
-        # Force a failure during the second (credit) leg.
-        # We patch _get_balance specifically for the receiver's fetch.
-        orig_get_balance = plugin._get_balance
-        async def failing_get_balance(guild_id, user_id):
-            if user_id == 2:
-                raise RuntimeError("Artificial config store failure")
-            return await orig_get_balance(guild_id, user_id)
+        # _transfer now does a single load+compute+save; patch the save to fail.
+        async def failing_save(cfg_obj):
+            raise RuntimeError("Artificial config store failure")
 
-        with patch.object(plugin, "_get_balance", side_effect=failing_get_balance):
+        with patch.object(plugin.config.store, "save", side_effect=failing_save):
             with pytest.raises(RuntimeError, match="Artificial config store failure"):
                 await plugin._transfer(100, 1, 2, 50)
 
-        # Verify rollback
+        # No save succeeded, so neither balance should have changed.
         sender_bal = await plugin._get_balance(100, 1)
         receiver_bal = await plugin._get_balance(100, 2)
-        assert sender_bal == 100, "Sender balance was not rolled back after credit failure."
-        assert receiver_bal == 50, "Receiver balance changed unexpectedly."
+        assert sender_bal == 100, "Sender balance should not change when save fails."
+        assert receiver_bal == 50, "Receiver balance should not change when save fails."
 
     @pytest.mark.asyncio
     async def test_concurrent_transfers_deadlock_prevention(self, plugin) -> None:
@@ -325,16 +320,20 @@ class TestEconomyConcurrency:
         await plugin._set_balance(100, 1, 100)
         await plugin._set_balance(100, 2, 100)
 
-        # Transfer A -> B and B -> A concurrently
+        # Transfer A -> B and B -> A concurrently.
         # Because we use a single per-guild lock, these serialize gracefully.
-        await asyncio.gather(
-            plugin._transfer(100, 1, 2, 50),
-            plugin._transfer(100, 2, 1, 50),
+        # The timeout ensures a real deadlock fails fast rather than hanging CI.
+        await asyncio.wait_for(
+            asyncio.gather(
+                plugin._transfer(100, 1, 2, 50),
+                plugin._transfer(100, 2, 1, 50),
+            ),
+            timeout=5,
         )
 
         sender_bal = await plugin._get_balance(100, 1)
         receiver_bal = await plugin._get_balance(100, 2)
-        
+
         # Balances should be exactly what they started with
         assert sender_bal == 100
         assert receiver_bal == 100


### PR DESCRIPTION
Addresses the three actionable issues from the CodeRabbit `CHANGES_REQUESTED` review on PR #41.

## Changes

### `easycord/plugins/economy.py`

**`daily` — I/O under lock** (`lines ~194-206`)
The early-return path called `ctx.respond()` while holding `_balance_lock`, blocking the guild-wide lock during a Discord API call. Fixed by capturing an `already_claimed` flag inside the lock and responding after releasing it.

**`_transfer` — half-applied disk state** (`lines ~119-140`)
The old implementation did two separate `_set_balance` saves (debit then credit). Between those two saves the on-disk state was inconsistent (sender debited, receiver not yet credited). Replaced with a single `load → compute both new balances in memory → save`, making the operation naturally atomic. If the save raises, neither balance is changed—no rollback logic needed.

### `tests/test_plugin_logic.py`

**`test_transfer_atomic_on_save_failure`** (renamed from `test_transfer_rollback_on_credit_failure`)
The refactored `_transfer` no longer calls `_get_balance` internally, so the old patch target no longer triggers. Updated to patch `config.store.save` (the single save point) and verify that a failed save leaves both balances unchanged.

**`test_concurrent_transfers_deadlock_prevention`** (`lines ~322-325`)
Wrapped `asyncio.gather` with `asyncio.wait_for(..., timeout=5)` so a real deadlock fails fast instead of hanging the entire CI suite.

## Test plan

- [x] `python -m pytest tests/ -q` → **540 passed**
- [x] `python -m compileall -q easycord tests` → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUUgzzC1Auz21X7hqoV8nh)_

## Summary by Sourcery

Ensure atomic balance updates and safe locking in the economy plugin, and harden related tests against deadlocks and persistence failures.

Bug Fixes:
- Make transfers atomic on disk by updating both sender and receiver balances via a single config load and save under the per-guild lock.
- Avoid holding the per-guild balance lock while performing Discord I/O in the daily reward command to prevent unnecessary contention and potential deadlocks.

Enhancements:
- Simplify balance update logic in the transfer operation by computing new balances in memory before persisting once.
- Prevent deadlock-induced hangs in concurrent transfer tests by enforcing a timeout around concurrent transfer execution.

Tests:
- Update the transfer failure test to assert that a failed config save leaves both balances unchanged.
- Wrap the concurrent transfer deadlock prevention test in a timeout to cause true deadlocks to fail fast instead of hanging CI.