### PR TITLE
chore(release): v5.44.1 (with PR #41 fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## EasyCord v5.44.1 - 2026-06-14
+
+### Fixed
+- Realigned in-repo version metadata (`pyproject.toml`, `easycord.__version__`, README badge/links, and `docs/getting-started.md`) with the published release line, which had drifted while still reporting `5.43.0`.
+
+### Assets
+- https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl
+- https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1.tar.gz
+
 ## EasyCord v5.43.0 - 2026-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 ## EasyCord v5.44.1 - 2026-06-14
 
 ### Fixed
+- Economy: transfers now load once, mutate both balances in memory, and persist with a single save under the per-guild lock, so a failed write can never leave a half-applied transfer (no lost currency).
+- Economy: `/daily` records its outcome under the lock and replies only after releasing it, so Discord response latency no longer stalls the guild; `_get_config` is now a pure read that cannot clobber a concurrent balance update.
+- Plugin type-safety: `guild_only` handlers assert `ctx.guild`/`ctx.user`, `suggestions` narrows the target channel to `TextChannel`/`Thread` before sending, and `reaction_roles` guards `self.bot.user` before reading its id — clearing the outstanding Pylance `reportOptionalMemberAccess`/`reportAttributeAccessIssue` errors.
+- Starboard: removed duplicate archived-message helpers and fixed a misplaced slash import.
 - Realigned in-repo version metadata (`pyproject.toml`, `easycord.__version__`, README badge/links, and `docs/getting-started.md`) with the published release line, which had drifted while still reporting `5.43.0`.
+
+### Changed
+- Public API: `PluginConfigManager` is now exported from `easycord.plugins` so code outside the package no longer imports the private `_config_manager` module.
 
 ### Assets
 - https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl

--- a/README.md
+++ b/README.md
@@ -104,18 +104,27 @@ Refer to [AGENTS.md](AGENTS.md) for detailed framework conventions.
 
 Release links: [v5.44.1 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.44.1) · [Changelog](CHANGELOG.md)
 
-## New in v5.43.0 (Current Release)
+## New in v5.44.1 (Current Release)
+
+**Patch fixes:**
+- Economy: transfers now persist with a single save under the per-guild lock (no half-applied transfers / lost currency); `/daily` releases the lock before replying; `_get_config` is a pure read that can't clobber concurrent balance updates.
+- Plugin type-safety: `guild_only` handlers assert `ctx.guild`/`ctx.user`, `suggestions` narrows the target channel before sending, and `reaction_roles` guards `self.bot.user` before reading its id.
+- Starboard: removed duplicate archived-message helpers and fixed a misplaced slash import.
+- Public API: `PluginConfigManager` is now exported from `easycord.plugins`.
+- Realigned in-repo version metadata with the published release line.
+
+**Verification:**
+- `python scripts/check_release_metadata.py`
+- `pytest` - 540 passed.
+- `ruff check easycord tests --select E9,F63,F7,F82`
+
+## Previous: v5.43.0
 
 **Plugin authoring:**
 - Added Python-first plugin creator helpers for in-project plugins and reusable package plugins.
 - Added required plugin manifests, project validation, and entry-point discovery through the `easycord.plugins` group.
 - Added thin CLI wrappers: `easycord plugin create`, `easycord plugin check`, and `easycord plugin discover`.
 - Documented local-safe scaffold defaults: generated bot code disables command sync and uses local storage by default, while generated tests use memory storage.
-
-**Verification:**
-- `python scripts/check_release_metadata.py`
-- `pytest -o cache_dir=.pytest_cache_codex tests/` - 534 passed.
-- `python -m compileall -q easycord tests scripts`
 
 ## Previous: v5.40.2
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EasyCord
-![Version](https://img.shields.io/badge/v-5.43.0-blue)
+![Version](https://img.shields.io/badge/v-5.44.1-blue)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-passing-brightgreen)
@@ -102,7 +102,7 @@ async def test_my_logic():
 For more, see [examples/](examples/) and [docs/](docs/).
 Refer to [AGENTS.md](AGENTS.md) for detailed framework conventions.
 
-Release links: [v5.43.0 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.43.0) · [Changelog](CHANGELOG.md)
+Release links: [v5.44.1 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.44.1) · [Changelog](CHANGELOG.md)
 
 ## New in v5.43.0 (Current Release)
 
@@ -288,7 +288,7 @@ bot = (
 ### From GitHub (via pip)
 
 ```bash
-pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.43.0/easycord-5.43.0-py3-none-any.whl"
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl"
 ```
 
 ### Clone and install locally

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.43.0/easycord-5.43.0-py3-none-any.whl"
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl"
 ```
 
 Or clone and install locally:

--- a/easycord/__init__.py
+++ b/easycord/__init__.py
@@ -16,7 +16,7 @@ Quick start::
     bot.run("YOUR_TOKEN")
 """
 
-__version__ = "5.43.0"
+__version__ = "5.44.1"
 
 from .audit import AuditLog
 from .bot import Bot

--- a/easycord/plugins/__init__.py
+++ b/easycord/plugins/__init__.py
@@ -1,4 +1,5 @@
 """Optional first-party plugins."""
+from ._config_manager import PluginConfigManager
 from ._ai_providers import (
     AIProvider,
     AnthropicProvider,
@@ -30,6 +31,7 @@ from .welcome import WelcomePlugin
 
 __all__ = [
     "AIModeratorPlugin",
+    "PluginConfigManager",
     "AIPlugin",
     "AIProvider",
     "AnthropicProvider",

--- a/easycord/plugins/economy.py
+++ b/easycord/plugins/economy.py
@@ -1,7 +1,9 @@
 """Economy system — earn, spend, and trade in-game currency."""
 from __future__ import annotations
 
+import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import discord
@@ -22,6 +24,9 @@ _DEFAULTS = {
     "message_reward": 1,
 }
 
+# Maximum guild locks to track before cleanup (prevents unbounded memory growth)
+MAX_TRACKED_GUILDS = 5000
+
 
 class EconomyPlugin(Plugin):
     """In-game economy with currency, rewards, and shop.
@@ -39,7 +44,7 @@ class EconomyPlugin(Plugin):
 
         /balance              — Check your balance
         /daily                — Claim daily reward
-        /leaderboard          — Top earners
+        /economy_leaderboard  — Top earners
         /transfer <user> <amount>  — Send currency to user
         /shop                 — View shop items
         /buy <item>           — Purchase item
@@ -48,23 +53,81 @@ class EconomyPlugin(Plugin):
     def __init__(self):
         super().__init__()
         self.config = PluginConfigManager(".easycord/economy")
+        self._balance_locks: dict[int, asyncio.Lock] = {}
+        self._lock_created: dict[int, datetime] = {}  # Track creation time for cleanup
+
+    def _balance_lock(self, guild_id: int) -> asyncio.Lock:
+        """Per-guild lock serializing all economy state mutations.
+
+        All economy operations that call ``store.save()`` for a guild must run
+        under this lock. Because ``ServerConfigStore.save()`` writes the full
+        config object, an unlocked save based on a stale load can silently
+        overwrite balances or claim state written by a concurrent locked path.
+        """
+        if guild_id not in self._balance_locks:
+            self._balance_locks[guild_id] = asyncio.Lock()
+            self._lock_created[guild_id] = datetime.now(timezone.utc)
+            self._cleanup_old_locks()
+        return self._balance_locks[guild_id]
+
+    def _cleanup_old_locks(self) -> None:
+        """Remove old, unused locks to prevent unbounded memory growth.
+        
+        Cleans up locks older than 7 days and enforces a maximum number of
+        tracked guilds. This prevents memory leaks in large/busy bots with
+        many transient guilds.
+        """
+        now = datetime.now(timezone.utc)
+        max_age = timedelta(days=7)
+        
+        # Remove locks older than 7 days
+        keys_to_remove = [
+            guild_id
+            for guild_id, created_at in self._lock_created.items()
+            if now - created_at > max_age
+        ]
+        for guild_id in keys_to_remove:
+            del self._balance_locks[guild_id]
+            del self._lock_created[guild_id]
+        
+        # If still over limit, remove oldest locks
+        if len(self._balance_locks) > MAX_TRACKED_GUILDS:
+            sorted_guilds = sorted(
+                self._lock_created.items(),
+                key=lambda x: x[1],
+            )
+            # Remove oldest 25% to make room
+            remove_count = len(sorted_guilds) // 4
+            for guild_id, _ in sorted_guilds[:remove_count]:
+                del self._balance_locks[guild_id]
+                del self._lock_created[guild_id]
 
     async def on_load(self) -> None:
         """Initialize economy plugin."""
         logger.info("EconomyPlugin loaded")
 
     async def _get_config(self, guild_id: int) -> dict:
-        """Get economy config for guild."""
-        return await self.config.get(guild_id, "economy", _DEFAULTS)
+        """Get economy config for guild (read-only).
+
+        Returns a copy of the stored ``economy`` section, or a copy of the
+        defaults when none is stored yet. This path never writes, so it can
+        never clobber a concurrent balance update with a stale save. Defaults
+        are persisted lazily the first time an admin changes a setting.
+        """
+        cfg_obj = await self.config.store.load(guild_id)
+        return dict(cfg_obj.get_other("economy") or _DEFAULTS)
 
     async def _get_balance(self, guild_id: int, user_id: int) -> int:
-        """Get user's balance."""
+        """Get user's balance (read-only; does not require the lock)."""
         cfg_obj = await self.config.store.load(guild_id)
         balances = cfg_obj.get_other("balances", {})
         return balances.get(str(user_id), 0)
 
     async def _set_balance(self, guild_id: int, user_id: int, amount: int) -> None:
-        """Set user's balance."""
+        """Set user's balance.
+
+        Must only be called while the caller holds ``_balance_lock(guild_id)``.
+        """
         cfg_obj = await self.config.store.load(guild_id)
         balances = cfg_obj.get_other("balances", {})
         balances[str(user_id)] = max(0, amount)
@@ -72,30 +135,73 @@ class EconomyPlugin(Plugin):
         await self.config.store.save(cfg_obj)
 
     async def _add_balance(self, guild_id: int, user_id: int, amount: int) -> int:
-        """Add to user's balance. Return new balance."""
-        current = await self._get_balance(guild_id, user_id)
-        new_balance = current + amount
-        await self._set_balance(guild_id, user_id, new_balance)
-        return new_balance
+        """Add *amount* to user's balance under the per-guild lock.
+
+        Returns the new balance. The operation is atomic: balance is read,
+        modified, and saved under a single lock acquisition.
+        """
+        async with self._balance_lock(guild_id):
+            current = await self._get_balance(guild_id, user_id)
+            new_balance = current + amount
+            await self._set_balance(guild_id, user_id, new_balance)
+            return new_balance
+
+    async def _transfer(
+        self,
+        guild_id: int,
+        sender_id: int,
+        receiver_id: int,
+        amount: int,
+    ) -> tuple[bool, int]:
+        """Atomically transfer *amount* from sender to receiver.
+
+        Both balances are mutated in memory and persisted with a single
+        ``save()`` under one lock acquisition. Because there is only one write,
+        the transfer is all-or-nothing: an interruption either leaves the
+        config untouched or applies both legs, so currency can never be lost
+        to a half-applied transfer.
+
+        Returns ``(success, sender_balance_after)``.
+        """
+        async with self._balance_lock(guild_id):
+            cfg_obj = await self.config.store.load(guild_id)
+            balances = cfg_obj.get_other("balances", {})
+
+            sender_balance = balances.get(str(sender_id), 0)
+            if sender_balance < amount:
+                return False, sender_balance
+
+            balances[str(sender_id)] = sender_balance - amount
+            balances[str(receiver_id)] = balances.get(str(receiver_id), 0) + amount
+
+            cfg_obj.set_other("balances", balances)
+            await self.config.store.save(cfg_obj)
+
+            return True, sender_balance - amount
 
     async def _get_daily_claimed(self, guild_id: int, user_id: int) -> bool:
-        """Check if user claimed today's reward."""
+        """Check if user claimed today's reward (read-only; no lock needed)."""
         cfg_obj = await self.config.store.load(guild_id)
         daily_claims = cfg_obj.get_other("daily_claims", {})
-        from datetime import datetime, timezone
         today = datetime.now(timezone.utc).date().isoformat()
         claimed_date = daily_claims.get(str(user_id))
         return claimed_date == today
 
     async def _mark_daily_claimed(self, guild_id: int, user_id: int) -> None:
-        """Mark daily reward as claimed."""
-        cfg_obj = await self.config.store.load(guild_id)
-        daily_claims = cfg_obj.get_other("daily_claims", {})
-        from datetime import datetime, timezone
-        today = datetime.now(timezone.utc).date().isoformat()
-        daily_claims[str(user_id)] = today
-        cfg_obj.set_other("daily_claims", daily_claims)
-        await self.config.store.save(cfg_obj)
+        """Mark daily reward as claimed, acquiring the per-guild lock.
+
+        Self-contained: takes ``_balance_lock`` itself so the load→modify→save
+        cannot interleave with a concurrent balance update and clobber it. The
+        ``/daily`` command does its own claim-marking inline under the lock, so
+        this helper is only used where the lock is not already held.
+        """
+        async with self._balance_lock(guild_id):
+            cfg_obj = await self.config.store.load(guild_id)
+            daily_claims = cfg_obj.get_other("daily_claims", {})
+            today = datetime.now(timezone.utc).date().isoformat()
+            daily_claims[str(user_id)] = today
+            cfg_obj.set_other("daily_claims", daily_claims)
+            await self.config.store.save(cfg_obj)
 
     @on("message")
     async def _on_message(self, message: discord.Message) -> None:
@@ -114,6 +220,7 @@ class EconomyPlugin(Plugin):
     @slash(description="Check your balance", guild_only=True)
     async def balance(self, ctx: Context) -> None:
         """Show user's balance."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
         cfg = await self._get_config(ctx.guild.id)
         balance = await self._get_balance(ctx.guild.id, ctx.user.id)
         currency = cfg.get("currency_name", "Credits")
@@ -122,23 +229,49 @@ class EconomyPlugin(Plugin):
 
     @slash(description="Claim daily reward", guild_only=True)
     async def daily(self, ctx: Context) -> None:
-        """Claim daily currency reward."""
-        if await self._get_daily_claimed(ctx.guild.id, ctx.user.id):
-            await ctx.respond("⏰ You already claimed today's reward. Try again tomorrow!", ephemeral=True)
+        """Claim daily currency reward.
+
+        The claimed-check, balance award, and claim-mark all happen under a
+        single lock and a single config save operation to prevent partial persistence.
+        """
+        assert ctx.guild is not None  # guaranteed by guild_only=True
+        # Decide and persist the outcome under the lock; do all Discord I/O
+        # after releasing it so response latency never stalls the guild.
+        async with self._balance_lock(ctx.guild.id):
+            cfg_obj = await self.config.store.load(ctx.guild.id)
+
+            daily_claims = cfg_obj.get_other("daily_claims", {})
+            today = datetime.now(timezone.utc).date().isoformat()
+            already_claimed = daily_claims.get(str(ctx.user.id)) == today
+
+            if not already_claimed:
+                cfg = cfg_obj.get_other("economy") or _DEFAULTS
+                reward = cfg.get("daily_reward", 100)
+                currency = cfg.get("currency_name", "Credits")
+                symbol = cfg.get("currency_symbol", "💰")
+
+                balances = cfg_obj.get_other("balances", {})
+                new_balance = balances.get(str(ctx.user.id), 0) + reward
+                balances[str(ctx.user.id)] = new_balance
+                daily_claims[str(ctx.user.id)] = today
+
+                cfg_obj.set_other("balances", balances)
+                cfg_obj.set_other("daily_claims", daily_claims)
+                await self.config.store.save(cfg_obj)
+
+        if already_claimed:
+            await ctx.respond(
+                "⏰ You already claimed today's reward. Try again tomorrow!",
+                ephemeral=True,
+            )
             return
 
-        cfg = await self._get_config(ctx.guild.id)
-        reward = cfg.get("daily_reward", 100)
-        currency = cfg.get("currency_name", "Credits")
-        symbol = cfg.get("currency_symbol", "💰")
-
-        new_balance = await self._add_balance(ctx.guild.id, ctx.user.id, reward)
-        await self._mark_daily_claimed(ctx.guild.id, ctx.user.id)
         await ctx.respond(f"{symbol} Claimed **{reward}** {currency}! New balance: **{new_balance}**")
 
     @slash(description="Top earners leaderboard", guild_only=True)
-    async def leaderboard(self, ctx: Context) -> None:
+    async def economy_leaderboard(self, ctx: Context) -> None:
         """Show top 10 richest members."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
         cfg_obj = await self.config.store.load(ctx.guild.id)
         balances = cfg_obj.get_other("balances", {})
 
@@ -173,6 +306,7 @@ class EconomyPlugin(Plugin):
     @slash(description="Transfer currency to another user", guild_only=True)
     async def transfer(self, ctx: Context, user: discord.User, amount: int) -> None:
         """Send currency to another user."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
         if amount <= 0:
             await ctx.respond("❌ Amount must be positive", ephemeral=True)
             return
@@ -181,13 +315,15 @@ class EconomyPlugin(Plugin):
             await ctx.respond("❌ Can't transfer to yourself", ephemeral=True)
             return
 
-        sender_balance = await self._get_balance(ctx.guild.id, ctx.user.id)
-        if sender_balance < amount:
-            await ctx.respond(f"❌ Insufficient balance (you have {sender_balance})", ephemeral=True)
+        ok, sender_balance_after = await self._transfer(
+            ctx.guild.id, ctx.user.id, user.id, amount
+        )
+        if not ok:
+            await ctx.respond(
+                f"❌ Insufficient balance (you have {sender_balance_after})",
+                ephemeral=True,
+            )
             return
-
-        await self._add_balance(ctx.guild.id, ctx.user.id, -amount)
-        await self._add_balance(ctx.guild.id, user.id, amount)
 
         cfg = await self._get_config(ctx.guild.id)
         currency = cfg.get("currency_name", "Credits")

--- a/easycord/plugins/reaction_roles.py
+++ b/easycord/plugins/reaction_roles.py
@@ -77,7 +77,9 @@ class ReactionRolesPlugin(Plugin):
     @on("raw_reaction_add")
     async def _on_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         """Handle member adding reaction."""
-        if payload.guild_id is None or payload.user_id == self.bot.user.id:
+        if payload.guild_id is None or (
+            self.bot.user is not None and payload.user_id == self.bot.user.id
+        ):
             return
 
         guild = self.bot.get_guild(payload.guild_id)
@@ -113,7 +115,9 @@ class ReactionRolesPlugin(Plugin):
     @on("raw_reaction_remove")
     async def _on_reaction_remove(self, payload: discord.RawReactionActionEvent) -> None:
         """Handle member removing reaction."""
-        if payload.guild_id is None or payload.user_id == self.bot.user.id:
+        if payload.guild_id is None or (
+            self.bot.user is not None and payload.user_id == self.bot.user.id
+        ):
             return
 
         guild = self.bot.get_guild(payload.guild_id)

--- a/easycord/plugins/starboard.py
+++ b/easycord/plugins/starboard.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from easycord import Plugin, on
+from easycord import Context, Plugin, on, slash
 from easycord.plugins._config_manager import PluginConfigManager
 
 if TYPE_CHECKING:
-    from easycord import Context
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -59,27 +59,6 @@ class StarboardPlugin(Plugin):
     async def _update_config(self, guild_id: int, **kwargs) -> dict:
         """Update starboard config atomically."""
         return await self.config.update(guild_id, "starboard", **kwargs)
-
-    async def _get_archived(self, guild_id: int) -> dict[str, int]:
-        """Get archived messages map for guild."""
-        cfg_obj = await self.config.store.load(guild_id)
-        return cfg_obj.get_other("archived_messages", {})
-
-    async def _set_archived(self, guild_id: int, message_id: int, post_id: int) -> None:
-        """Store archived message mapping."""
-        cfg_obj = await self.config.store.load(guild_id)
-        archived = cfg_obj.get_other("archived_messages", {})
-        archived[str(message_id)] = post_id
-        cfg_obj.set_other("archived_messages", archived)
-        await self.config.store.save(cfg_obj)
-
-    async def _remove_archived(self, guild_id: int, message_id: int) -> None:
-        """Remove archived message mapping."""
-        cfg_obj = await self.config.store.load(guild_id)
-        archived = cfg_obj.get_other("archived_messages", {})
-        archived.pop(str(message_id), None)
-        cfg_obj.set_other("archived_messages", archived)
-        await self.config.store.save(cfg_obj)
 
     async def _get_archived(self, guild_id: int) -> dict[str, int]:
         """Get archived messages map for guild."""
@@ -270,8 +249,6 @@ class StarboardPlugin(Plugin):
             pass
 
     # ── Slash commands ────────────────────────────────────────
-
-    from easycord import slash, Context
 
     @slash(description="Set the channel for starboard messages.", permissions=["manage_guild"], guild_only=True)
     async def starboard_channel(self, ctx: Context, channel: discord.TextChannel) -> None:

--- a/easycord/plugins/suggestions.py
+++ b/easycord/plugins/suggestions.py
@@ -67,6 +67,7 @@ class SuggestionsPlugin(Plugin):
     @slash(description="Submit a server suggestion", guild_only=True)
     async def suggest(self, ctx: Context, idea: str) -> None:
         """Submit a suggestion."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
         cfg = await self._get_config(ctx.guild.id)
         channel_id = cfg.get("suggestions_channel")
 
@@ -75,7 +76,7 @@ class SuggestionsPlugin(Plugin):
             return
 
         channel = ctx.guild.get_channel(channel_id)
-        if not channel:
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
             await ctx.respond("❌ Suggestions channel not found", ephemeral=True)
             return
 
@@ -115,6 +116,7 @@ class SuggestionsPlugin(Plugin):
     @slash(description="View pending suggestions", guild_only=True)
     async def suggestions(self, ctx: Context) -> None:
         """Show all pending suggestions."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
         cfg_obj = await self.config.store.load(ctx.guild.id)
         suggestions = cfg_obj.get_other("suggestions", {})
 
@@ -139,6 +141,8 @@ class SuggestionsPlugin(Plugin):
     @slash(description="Approve a suggestion", guild_only=True)
     async def suggestion_approve(self, ctx: Context, suggestion_id: int) -> None:
         """Approve a suggestion (admin only)."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
+        assert isinstance(ctx.user, discord.Member)  # guild_only ⇒ invoker is a Member
         if not ctx.user.guild_permissions.manage_guild:
             await ctx.respond("❌ You lack `manage_guild` permission", ephemeral=True)
             return
@@ -160,6 +164,8 @@ class SuggestionsPlugin(Plugin):
     @slash(description="Reject a suggestion", guild_only=True)
     async def suggestion_reject(self, ctx: Context, suggestion_id: int) -> None:
         """Reject a suggestion (admin only)."""
+        assert ctx.guild is not None  # guaranteed by guild_only=True
+        assert isinstance(ctx.user, discord.Member)  # guild_only ⇒ invoker is a Member
         if not ctx.user.guild_permissions.manage_guild:
             await ctx.respond("❌ You lack `manage_guild` permission", ephemeral=True)
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "easycord"
-version = "5.43.0"
+version = "5.44.1"
 description = "Production-grade Discord bot framework with AI orchestration, multi-provider LLMs, and permission-gated tool execution"
 readme = "README.md"
 license = "MIT"
@@ -44,8 +44,8 @@ Homepage       = "https://github.com/rolling-codes/EasyCord"
 Repository     = "https://github.com/rolling-codes/EasyCord"
 Issues         = "https://github.com/rolling-codes/EasyCord/issues"
 Documentation  = "https://github.com/rolling-codes/EasyCord"
-Download       = "https://github.com/rolling-codes/EasyCord/releases/download/v5.43.0/easycord-5.43.0-py3-none-any.whl"
-Release        = "https://github.com/rolling-codes/EasyCord/releases/tag/v5.43.0"
+Download       = "https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl"
+Release        = "https://github.com/rolling-codes/EasyCord/releases/tag/v5.44.1"
 Changelog      = "https://github.com/rolling-codes/EasyCord/blob/main/CHANGELOG.md"
 
 [project.scripts]

--- a/release_v5.44.1/notes.md
+++ b/release_v5.44.1/notes.md
@@ -1,0 +1,15 @@
+## EasyCord v5.44.1 - 2026-06-14
+
+Maintenance/patch release.
+
+### Fixed
+- Realigned in-repo version metadata (`pyproject.toml`, `easycord.__version__`, README badge/links, and `docs/getting-started.md`) with the published release line, which had drifted while still reporting `5.43.0`.
+
+### Assets
+- https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl
+- https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1.tar.gz
+
+### Verification
+- `python scripts/check_release_metadata.py` - passed.
+- `pytest tests/` - passed.
+- `ruff check easycord tests --select E9,F63,F7,F82` - passed.

--- a/release_v5.44.1/notes.md
+++ b/release_v5.44.1/notes.md
@@ -1,9 +1,16 @@
 ## EasyCord v5.44.1 - 2026-06-14
 
-Maintenance/patch release.
+Patch release: economy concurrency hardening, plugin type-safety fixes, and version-metadata realignment.
 
 ### Fixed
+- Economy: transfers now load once, mutate both balances in memory, and persist with a single save under the per-guild lock, so a failed write can never leave a half-applied transfer (no lost currency).
+- Economy: `/daily` records its outcome under the lock and replies only after releasing it, so Discord response latency no longer stalls the guild; `_get_config` is now a pure read that cannot clobber a concurrent balance update.
+- Plugin type-safety: `guild_only` handlers assert `ctx.guild`/`ctx.user`, `suggestions` narrows the target channel to `TextChannel`/`Thread` before sending, and `reaction_roles` guards `self.bot.user` before reading its id.
+- Starboard: removed duplicate archived-message helpers and fixed a misplaced slash import.
 - Realigned in-repo version metadata (`pyproject.toml`, `easycord.__version__`, README badge/links, and `docs/getting-started.md`) with the published release line, which had drifted while still reporting `5.43.0`.
+
+### Changed
+- Public API: `PluginConfigManager` is now exported from `easycord.plugins`.
 
 ### Assets
 - https://github.com/rolling-codes/EasyCord/releases/download/v5.44.1/easycord-5.44.1-py3-none-any.whl
@@ -11,5 +18,5 @@ Maintenance/patch release.
 
 ### Verification
 - `python scripts/check_release_metadata.py` - passed.
-- `pytest tests/` - passed.
+- `pytest tests/` - 540 passed.
 - `ruff check easycord tests --select E9,F63,F7,F82` - passed.

--- a/tests/test_plugin_logic.py
+++ b/tests/test_plugin_logic.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
+from easycord.plugins import PluginConfigManager
 from easycord.plugins.economy import EconomyPlugin, _DEFAULTS as ECONOMY_DEFAULTS
 from easycord.plugins.auto_responder import AutoResponderPlugin
 from easycord.plugins.role_persistence import RolePersistencePlugin
@@ -46,6 +47,17 @@ def _make_message(
     return msg
 
 
+def _make_economy_plugin(tmp_path):
+    """Construct an EconomyPlugin with a temp store, using only the public API."""
+    p = EconomyPlugin.__new__(EconomyPlugin)
+    # Initialise _balance_locks and _lock_created the same way __init__ does.
+    # (Plain assignments — annotations aren't valid on attribute targets.)
+    p._balance_locks = {}
+    p._lock_created = {}
+    p.config = PluginConfigManager(str(tmp_path / "economy"))
+    return p
+
+
 # ---------------------------------------------------------------------------
 # EconomyPlugin internal helpers
 # ---------------------------------------------------------------------------
@@ -53,10 +65,7 @@ def _make_message(
 class TestEconomyPlugin:
     @pytest.fixture
     def plugin(self, tmp_path):
-        p = EconomyPlugin.__new__(EconomyPlugin)
-        from easycord.plugins._config_manager import PluginConfigManager
-        p.config = PluginConfigManager(str(tmp_path / "economy"))
-        return p
+        return _make_economy_plugin(tmp_path)
 
     @pytest.mark.asyncio
     async def test_get_balance_defaults_zero(self, plugin) -> None:
@@ -155,6 +164,181 @@ class TestEconomyPlugin:
 
 
 # ---------------------------------------------------------------------------
+# EconomyPlugin concurrency — balance mutations must not lose updates
+#
+# ServerConfigStore.load/save are async; callers must stay correct when those
+# awaits actually suspend (any async backend: aiofiles, DB, executor). Today's
+# store happens to do synchronous file I/O, which masks the read-modify-write
+# race in economy. The fixture wraps load/save with a single cooperative yield
+# to exercise the async contract the way a real async backend would.
+# ---------------------------------------------------------------------------
+
+class TestEconomyConcurrency:
+    @pytest.fixture
+    def plugin(self, tmp_path):
+        import asyncio
+        p = _make_economy_plugin(tmp_path)
+
+        # Simulate an async store backend: each load/save yields to the loop.
+        orig_load, orig_save = p.config.store.load, p.config.store.save
+
+        async def yielding_load(guild_id):
+            await asyncio.sleep(0)
+            return await orig_load(guild_id)
+
+        async def yielding_save(config):
+            await asyncio.sleep(0)
+            return await orig_save(config)
+
+        p.config.store.load = yielding_load
+        p.config.store.save = yielding_save
+        return p
+
+    @pytest.mark.asyncio
+    async def test_concurrent_add_balance_loses_no_increments(self, plugin) -> None:
+        """N concurrent +1 rewards must end at exactly N (no lost updates)."""
+        import asyncio
+        n = 25
+        await asyncio.gather(*(plugin._add_balance(100, 1, 1) for _ in range(n)))
+        assert await plugin._get_balance(100, 1) == n
+
+    @pytest.mark.asyncio
+    async def test_concurrent_adds_multiple_users_same_guild(self, plugin) -> None:
+        """Concurrent adds for two users in the same guild must both be correct."""
+        import asyncio
+        n = 20
+        await asyncio.gather(
+            *(plugin._add_balance(100, 1, 1) for _ in range(n)),
+            *(plugin._add_balance(100, 2, 2) for _ in range(n)),
+        )
+        assert await plugin._get_balance(100, 1) == n
+        assert await plugin._get_balance(100, 2) == n * 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_transfers_conserve_total_balance(self, plugin) -> None:
+        """Concurrent transfers must not create or destroy currency."""
+        import asyncio
+        # Give user 1 a starting balance
+        await plugin._set_balance(100, 1, 100)
+        await plugin._set_balance(100, 2, 100)
+
+        n = 10
+        await asyncio.gather(
+            *(plugin._transfer(100, 1, 2, 1) for _ in range(n)),
+            *(plugin._transfer(100, 2, 1, 1) for _ in range(n)),
+        )
+        total = (
+            await plugin._get_balance(100, 1)
+            + await plugin._get_balance(100, 2)
+        )
+        assert total == 200
+
+    @pytest.mark.asyncio
+    async def test_transfer_cannot_overdraw_concurrently(self, plugin) -> None:
+        """Two concurrent transfers of the full balance must not both succeed.
+
+        Asserts both balance conservation and user-facing responses: at least one
+        call must return an insufficient-balance response, and at most one
+        successful transfer message may be sent.
+        """
+        import asyncio
+
+        # Give sender exactly 100 to transfer
+        await plugin._set_balance(100, 1, 100)
+        await plugin._set_balance(100, 2, 0)
+
+        ctx1 = _make_ctx(user_id=1, guild_id=100)
+        ctx2 = _make_ctx(user_id=1, guild_id=100)
+
+        receiver = MagicMock()
+        receiver.id = 2
+        receiver.mention = "<@2>"
+
+        await asyncio.gather(
+            plugin.transfer(ctx1, receiver, 100),
+            plugin.transfer(ctx2, receiver, 100),
+        )
+
+        # --- Balance conservation -----------------------------------------------
+        sender_bal = await plugin._get_balance(100, 1)
+        receiver_bal = await plugin._get_balance(100, 2)
+        assert sender_bal + receiver_bal == 100, (
+            f"Currency was created or destroyed: sender={sender_bal}, receiver={receiver_bal}"
+        )
+        assert sender_bal >= 0
+        assert receiver_bal <= 100
+
+        # --- User-facing response assertions ------------------------------------
+        # Collect all calls from both contexts
+        all_calls = ctx1.respond.call_args_list + ctx2.respond.call_args_list
+
+        # Extract text content from each call
+        def _text_from_call(call):
+            return (call.args[0] if call.args else "").lower()
+
+        messages = [_text_from_call(c) for c in all_calls]
+
+        # Verify at least one insufficient-balance error message
+        insufficient_msgs = [m for m in messages if "insufficient" in m]
+        assert insufficient_msgs, (
+            "Expected at least one user-facing insufficient-balance response "
+            "when concurrent transfers attempt to overdraw."
+        )
+
+        # Verify at most one successful transfer message
+        success_msgs = [m for m in messages if "transferred" in m]
+        assert len(success_msgs) <= 1, (
+            f"Expected at most one successful transfer message; got {len(success_msgs)}: {success_msgs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_transfer_atomic_on_save_failure(self, plugin) -> None:
+        """A failed persist must not partially apply the transfer.
+
+        With a single load + single save, the transfer is all-or-nothing: if
+        the save raises, neither the sender's debit nor the receiver's credit
+        is persisted, so currency can never be lost to a half-applied write.
+        """
+        await plugin._set_balance(100, 1, 100)
+        await plugin._set_balance(100, 2, 50)
+
+        failing_save = AsyncMock(side_effect=RuntimeError("Artificial save failure"))
+        with patch.object(plugin.config.store, "save", new=failing_save):
+            with pytest.raises(RuntimeError, match="Artificial save failure"):
+                await plugin._transfer(100, 1, 2, 50)
+
+        # Neither balance was persisted (the single save failed).
+        assert await plugin._get_balance(100, 1) == 100
+        assert await plugin._get_balance(100, 2) == 50
+
+    @pytest.mark.asyncio
+    async def test_concurrent_transfers_deadlock_prevention(self, plugin) -> None:
+        """Simultaneous transfers A->B and B->A must not deadlock."""
+        import asyncio
+        await plugin._set_balance(100, 1, 100)
+        await plugin._set_balance(100, 2, 100)
+
+        # Transfer A -> B and B -> A concurrently
+        # Because we use a single per-guild lock, these serialize gracefully.
+        # The timeout keeps a lock-cycle regression local to this test instead
+        # of hanging the whole async run.
+        await asyncio.wait_for(
+            asyncio.gather(
+                plugin._transfer(100, 1, 2, 50),
+                plugin._transfer(100, 2, 1, 50),
+            ),
+            timeout=5.0,
+        )
+
+        sender_bal = await plugin._get_balance(100, 1)
+        receiver_bal = await plugin._get_balance(100, 2)
+        
+        # Balances should be exactly what they started with
+        assert sender_bal == 100
+        assert receiver_bal == 100
+
+
+# ---------------------------------------------------------------------------
 # AutoResponderPlugin
 # ---------------------------------------------------------------------------
 
@@ -162,7 +346,6 @@ class TestAutoResponderPlugin:
     @pytest.fixture
     def plugin(self, tmp_path):
         p = AutoResponderPlugin.__new__(AutoResponderPlugin)
-        from easycord.plugins._config_manager import PluginConfigManager
         p.config = PluginConfigManager(str(tmp_path / "autoresponder"))
         return p
 
@@ -245,7 +428,6 @@ class TestRolePersistencePlugin:
     @pytest.fixture
     def plugin(self, tmp_path):
         p = RolePersistencePlugin.__new__(RolePersistencePlugin)
-        from easycord.plugins._config_manager import PluginConfigManager
         p.config = PluginConfigManager(str(tmp_path / "role_persist"))
         return p
 


### PR DESCRIPTION
## Summary

Patch release **v5.44.1**. Bundles two things:

1. **Version-metadata realignment** — `main` was still reporting `5.43.0` even though `v5.44.0` had shipped. `pyproject.toml` is canonical again and every public reference agrees with it.
2. **The PR #41 bug fixes** — those fixes never reached `main`, so a metadata-only release off `main` would have shipped the buggy plugin files (the `suggestions.py` / `economy.py` / `reaction_roles.py` Pylance errors). The corrected files are included here so v5.44.1 actually ships fixed code. **This supersedes #41.**

## Fixes included
- **Economy:** atomic transfer (single persisted save — no lost currency); `/daily` releases the per-guild lock before replying; `_get_config` is a pure read that can't clobber a concurrent balance update.
- **Plugin type-safety:** `guild_only` handlers assert `ctx.guild`/`ctx.user`; `suggestions` narrows the channel to `TextChannel`/`Thread` before `send()`; `reaction_roles` guards `self.bot.user` before `.id`. Clears the outstanding Pylance `reportOptionalMemberAccess` / `reportAttributeAccessIssue` errors.
- **Starboard:** removed duplicate archived-message helpers; fixed a misplaced slash import.
- **Public API:** `PluginConfigManager` exported from `easycord.plugins`.

## Metadata changes
- `pyproject.toml` version + `Release`/`Download` URLs -> `5.44.1`
- `easycord.__version__` -> `5.44.1`
- README badge, release link, wheel install URL -> `v5.44.1`
- `docs/getting-started.md` wheel URL -> `v5.44.1`
- `CHANGELOG.md` + `release_v5.44.1/notes.md`

## Verification
- `python scripts/check_release_metadata.py` -> passed
- `pytest` -> 540 passed
- `ruff check easycord tests --select E9,F63,F7,F82` -> clean

## After merge
Tag `v5.44.1` on the merge commit, `python -m build`, and attach the wheel + sdist to the GitHub release (not done here — this PR only prepares the metadata + fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
