### PR TITLE
fix(tests): narrow ctx.member type for Pylance reportOptionalMemberAccess

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -46,6 +46,7 @@ def test_fake_context_builder_configures_context() -> None:
     assert ctx.guild.id == 987
     assert ctx.guild.name == "Builders"
     assert ctx.is_admin is True
+    assert ctx.member is not None
     assert ctx.member is ctx.user
     assert ctx.member.guild_permissions.manage_messages is True
     assert [role.id for role in ctx.member.roles] == [10, 20]


### PR DESCRIPTION
## Summary

- Adds `assert ctx.member is not None` before attribute accesses on `ctx.member` in `test_fake_context_builder_configures_context`
- Resolves two Pylance `reportOptionalMemberAccess` errors on `.guild_permissions` and `.roles`
- No behavior change — the assertion is already guaranteed by the builder under test

## Test plan

- [ ] `pytest tests/test_testing.py -v` passes
- [ ] No Pylance errors on lines 50-52 of `test_testing.py`

## Summary by Sourcery

Tests:
- Add an explicit non-None assertion for ctx.member in the fake context builder test to clear static analysis errors without changing runtime behavior.