### PR TITLE
refactor: module splits, ai_moderator type safety + prompt injection fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,64 @@ The `easycord` console script (`easycord/cli.py`) is the dev-facing CLI: `easyco
 
 - [Architecture](context/architecture.md) — layers, mixins, module map
 - [Conventions](context/conventions.md) — naming rules, key invariants
+
+## Architecture quick-reference
+
+**Bot** (`bot.py`) composes `discord.Client` with four mixins — `_bot_commands.py`, `_bot_events.py`, `_bot_guild.py`, `_bot_plugins.py`. Each mixin imports `_BotBase` only under `TYPE_CHECKING` using a per-module `_MixinBase = _BotBase` alias so static checkers see the full `Bot` surface but no runtime import cycle is created. Never instantiate `_BotBase`; it is a phantom type only.
+
+**Context** (`context.py` + `_context_*.py`) — use `ctx.user` / `ctx.member`. `ctx.author` does not exist. `ctx.is_admin` is a property, not a method.
+
+**Plugin** (`plugin.py`) — subclass `Plugin`, decorate methods with `@slash` / `@on`, then call `bot.add_plugin(plugin_instance)`. The plugin scanner (`_plugin_scanner.py`) wires commands automatically. Per-guild state belongs in the database layer, never on `self` (the Plugin instance).
+
+**i18n** — `LocalizationManager` in `i18n.py`, split across `_i18n_locale.py`, `_i18n_diagnostics.py`, `_i18n_validation.py`. Diagnostic modes: `SILENT`, `WARN`, `STRICT`. Never hardcode response strings in plugins; always look them up via `ctx.t(...)`.
+
+**AI orchestration** — `orchestrator.py` routes via `FallbackStrategy` (advances through providers on exhaustion, raises `IndexError` when all fail). AI providers are lazy-imported from `plugins/_ai_providers.py` via `easycord.__getattr__`. `ToolLimiter` methods (`check_limit`, `reset_user`, `reset_tool`) are async — always await them.
+
+**Command registration split** — `_command_callbacks.py` builds the actual callback wrappers; `_command_registration.py` handles option injection, choice population, and context-menu registration. Both are consumed by `_bot_commands.py`.
+
+## Testing
+
+`easycord.testing` provides everything needed to exercise commands without a Discord connection.
+
+**Preferred patterns:**
+
+```python
+# Simple invoke — returns FakeContext with .last_response / .responses
+ctx = await invoke(bot, "ping")
+ctx.assert_content("Pong!")
+
+# Fluent builder — when you need locale, roles, DM context, etc.
+ctx = (
+    FakeContextBuilder()
+    .with_user(42, name="alice")
+    .in_guild(100)
+    .as_admin()
+    .with_roles(999)
+    .build()
+)
+
+# Plugin construction in tests — use __new__ and set _bot directly
+plugin = MyPlugin.__new__(MyPlugin)
+plugin._bot = bot   # set _bot, NOT bot (bot is a property that raises if _bot is None)
+Plugin.__init__(plugin)
+```
+
+Available invoke helpers: `invoke`, `invoke_autocomplete`, `invoke_component`, `invoke_modal`, `invoke_user_command`, `invoke_message_command`.
+
+**Channel send safety** — before calling `.send()` on any channel obtained from `ctx` or Discord, narrow its type first. Use the `SENDABLE_CHANNEL_TYPES` tuple (defined in `easycord/helpers/tools.py` or a local `_utils.py`). Bare `.send()` on unnarrowed channel types will fail at runtime on DM-incompatible channels.
+
+```python
+from easycord.helpers.tools import SENDABLE_CHANNEL_TYPES
+if isinstance(channel, SENDABLE_CHANNEL_TYPES):
+    await channel.send(...)
+```
+
+## Key invariants
+
+- `ToolLimiter` methods are async — always `await check_limit(...)`.
+- Cooldown sentinels in `LevelsPlugin._cooldowns` default to `float("-inf")`, not `0.0` — ensures first message always passes.
+- `ctx.is_admin` is a property — never call `ctx.is_admin()`.
+- `ctx.user` / `ctx.member` are correct; `ctx.author` does not exist.
+- `@ai_tool` requires an explicit `ToolSafety` annotation to register.
+- CI actions are pinned to `actions/checkout@v4` and `actions/setup-python@v5` — v6 does not exist.
+- `sync_commands()` raises `RuntimeError` on removals unless `confirm_removals=True` is passed explicitly.

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import os
-import time
-from typing import TYPE_CHECKING, Callable, Union
+from typing import TYPE_CHECKING, Callable
 
 import discord
 from discord import app_commands
-import logging
 
+from ._command_callbacks import build_slash_callback
+from ._command_registration import (
+    autocomplete_options,
+    inject_choices,
+    register_context_menu,
+    register_slash,
+)
 from .context import Context
 from .middleware import build_chain
 
@@ -27,8 +33,6 @@ logger = logging.getLogger("easycord")
 
 class _CommandsMixin(_MixinBase):
     """Mixin: slash commands, context menus, and subcommand groups."""
-
-    # ── Slash commands ────────────────────────────────────────
 
     def slash(
         self,
@@ -51,92 +55,47 @@ class _CommandsMixin(_MixinBase):
         allowed_contexts: app_commands.AppCommandContext | None = None,
         allowed_installs: app_commands.AppInstallationType | None = None,
     ) -> Callable:
-        """Decorator that registers a top-level slash command.
-
-        Parameters
-        ----------
-        permissions:
-            List of ``discord.Permissions`` attribute names the invoking member
-            must have (e.g. ``["kick_members", "ban_members"]``). Responds with
-            an ephemeral error and skips the command if any are missing.
-        cooldown:
-            Per-user cooldown in seconds. The command is blocked ephemerally
-            until the window expires. Cooldowns are tracked in memory on this
-            bot process and are not shared across shards or processes.
-        autocomplete:
-            Dict mapping parameter names to async callbacks that return
-            suggestions. Each callback receives the current typed string and
-            returns a ``list[str]``::
-
-                async def fruit_choices(current: str) -> list[str]:
-                    fruits = ["apple", "banana", "cherry"]
-                    return [f for f in fruits if current.lower() in f]
-
-                @bot.slash(description="Pick a fruit", autocomplete={"fruit": fruit_choices})
-                async def pick(ctx, fruit: str):
-                    await ctx.respond(f"You picked {fruit}!")
-        """
+        """Decorator that registers a top-level slash command."""
 
         def decorator(func: Callable) -> Callable:
-            primary = name or func.__name__
-            self._register_slash(
-                func,
-                name=primary,
-                description=description,
-                guild_id=guild_id,
-                guild_only=guild_only,
-                require_admin=require_admin,
-                ephemeral=ephemeral,
-                permissions=permissions if permissions is not None else getattr(func, "_slash_permissions", None),
-                cooldown=cooldown if cooldown is not None else getattr(func, "_slash_cooldown", None),
-                cooldown_rate=getattr(func, "_slash_cooldown_rate", cooldown_rate),
-                cooldown_bucket=getattr(func, "_slash_cooldown_bucket", cooldown_bucket),
-                premium_required=getattr(func, "_slash_premium_required", premium_required),
-                autocomplete=autocomplete,
-                choices=choices,
-                nsfw=nsfw,
-                allowed_contexts=allowed_contexts or getattr(func, "_slash_allowed_contexts", None),
-                allowed_installs=allowed_installs or getattr(func, "_slash_allowed_installs", None),
-            )
-            for alias in (aliases or []):
+            for command_name in [name or func.__name__] + list(aliases or []):
                 self._register_slash(
                     func,
-                    name=alias,
+                    name=command_name,
                     description=description,
                     guild_id=guild_id,
                     guild_only=guild_only,
                     require_admin=require_admin,
                     ephemeral=ephemeral,
-                    permissions=permissions if permissions is not None else getattr(func, "_slash_permissions", None),
-                    cooldown=cooldown if cooldown is not None else getattr(func, "_slash_cooldown", None),
-                    cooldown_rate=getattr(func, "_slash_cooldown_rate", cooldown_rate),
-                    cooldown_bucket=getattr(func, "_slash_cooldown_bucket", cooldown_bucket),
-                    premium_required=getattr(func, "_slash_premium_required", premium_required),
+                    permissions=permissions
+                    if permissions is not None
+                    else getattr(func, "_slash_permissions", None),
+                    cooldown=cooldown
+                    if cooldown is not None
+                    else getattr(func, "_slash_cooldown", None),
+                    cooldown_rate=getattr(
+                        func, "_slash_cooldown_rate", cooldown_rate
+                    ),
+                    cooldown_bucket=getattr(
+                        func, "_slash_cooldown_bucket", cooldown_bucket
+                    ),
+                    premium_required=getattr(
+                        func, "_slash_premium_required", premium_required
+                    ),
                     autocomplete=autocomplete,
                     choices=choices,
                     nsfw=nsfw,
-                    allowed_contexts=allowed_contexts or getattr(func, "_slash_allowed_contexts", None),
-                    allowed_installs=allowed_installs or getattr(func, "_slash_allowed_installs", None),
+                    allowed_contexts=allowed_contexts
+                    or getattr(func, "_slash_allowed_contexts", None),
+                    allowed_installs=allowed_installs
+                    or getattr(func, "_slash_allowed_installs", None),
                 )
             return func
 
         return decorator
 
     async def watch_plugins(self, *plugin_names: str, interval: float = 1.0) -> None:
-        """Watch plugin source files and run lifecycle reloads on changes.
-
-        Intended for development only — run inside a task or background thread.
-        Calls ``reload_plugin(name)`` whenever the source file's mtime changes.
-        This re-runs the existing plugin instance's unload/load hooks; it does
-        not reload Python modules or recreate command objects.
-
-        Example::
-
-            @bot.on("ready")
-            async def start_watcher():
-                import asyncio
-                asyncio.create_task(bot.watch_plugins("MyPlugin"))
-        """
+        """Watch plugin source files and run lifecycle reloads on changes."""
         mtimes: dict[str, float] = {}
         while True:
             for name in plugin_names:
@@ -175,144 +134,26 @@ class _CommandsMixin(_MixinBase):
         premium_required: bool = False,
         command_name: str | None = None,
     ) -> Callable:
-        """Build a discord.py-compatible callback with guild, permission, and cooldown guards."""
-        sig = inspect.signature(func)
-        user_params = list(sig.parameters.values())[1:]
-        _cooldown_last_used: dict[int, list[float]] = {}
-        if cooldown is not None and cooldown_rate < 1:
-            raise ValueError("cooldown_rate must be at least 1")
-        if cooldown_bucket not in {"user", "guild", "global"}:
-            raise ValueError(
-                "cooldown_bucket must be 'user', 'guild', or 'global'"
-            )
-
-        # Merge require_admin into the permissions list at build time so the
-        # check is handled by the single unified permissions path below.
-        effective_permissions = list(permissions or [])
-        if require_admin and "administrator" not in effective_permissions:
-            effective_permissions.append("administrator")
-
-        async def callback(interaction: discord.Interaction, **kwargs) -> None:
-            ctx = Context(interaction)
-            if ephemeral:
-                ctx._force_ephemeral = True
-
-            async def invoke() -> None:
-                if guild_only and not ctx.guild:
-                    await ctx.respond(
-                        ctx.t(
-                            "errors.guild_only",
-                            default="This command can only be used inside a server.",
-                        ),
-                        ephemeral=True,
-                    )
-                    return
-                if effective_permissions:
-                    if not ctx.guild:
-                        await ctx.respond(
-                            ctx.t(
-                                "errors.guild_only",
-                                default="This command can only be used inside a server.",
-                            ),
-                            ephemeral=True,
-                        )
-                        return
-                    member = ctx.guild.get_member(ctx.user.id)
-                    if not member:
-                        await ctx.respond(
-                            ctx.t(
-                                "errors.permissions_unverified",
-                                default="Could not verify your permissions.",
-                            ),
-                            ephemeral=True,
-                        )
-                        return
-                    missing = [
-                        p for p in effective_permissions
-                        if not getattr(member.guild_permissions, p, False)
-                    ]
-                    if missing:
-                        await ctx.respond(
-                            ctx.t(
-                                "errors.permissions_missing",
-                                default="You need the following permission(s): {permissions}.",
-                                permissions=", ".join(missing),
-                            ),
-                            ephemeral=True,
-                        )
-                        return
-                if premium_required and not ctx.entitlements:
-                    await ctx.respond(
-                        ctx.t(
-                            "errors.premium_required",
-                            default="This command requires an active premium subscription.",
-                        ),
-                        ephemeral=True,
-                    )
-                    return
-                if cooldown is not None:
-                    if cooldown_bucket == "guild":
-                        bucket_key = ctx.guild.id if ctx.guild else ctx.user.id
-                    elif cooldown_bucket == "global":
-                        bucket_key = 0
-                    else:
-                        bucket_key = ctx.user.id
-                    now = time.monotonic()
-                    used_at = [
-                        ts
-                        for ts in _cooldown_last_used.get(bucket_key, [])
-                        if now - ts < cooldown
-                    ]
-                    if len(used_at) >= cooldown_rate:
-                        remaining = cooldown - (now - used_at[0])
-                        await ctx.respond(
-                            ctx.t(
-                                "errors.cooldown",
-                                default="This command is on cooldown. Try again in {seconds:.1f}s.",
-                                seconds=remaining,
-                            ),
-                            ephemeral=True,
-                        )
-                        return
-                    used_at.append(now)
-                    _cooldown_last_used[bucket_key] = used_at
-                try:
-                    await func(ctx, **kwargs)
-                except Exception as exc:
-                    # Priority: per-command → plugin.on_error → global → raise
-                    per_cmd = (
-                        getattr(self, "_command_error_handlers", {}).get(command_name)
-                        if command_name
-                        else None
-                    )
-                    if per_cmd is not None:
-                        await per_cmd(ctx, exc)
-                        return
-                    plugin = getattr(func, "__self__", None)
-                    if plugin is not None:
-                        from .plugin import Plugin as _Plugin
-                        if isinstance(plugin, _Plugin):
-                            plugin_on_error = type(plugin).on_error
-                            base_on_error = _Plugin.on_error
-                            if plugin_on_error is not base_on_error:
-                                await plugin.on_error(ctx, exc)
-                                return
-                    if self._error_handler is not None:
-                        await self._error_handler(ctx, exc)
-                    else:
-                        raise
-
-            await build_chain(ctx, invoke, self._middleware)()
-
-        interaction_param = inspect.Parameter(
-            "interaction",
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=discord.Interaction,
+        """Build a discord.py-compatible callback with guard checks."""
+        return build_slash_callback(
+            self,
+            func,
+            context_factory=lambda interaction: Context(interaction),
+            chain_builder=lambda ctx, invoke, middleware: build_chain(
+                ctx,
+                invoke,
+                middleware,
+            ),
+            guild_only=guild_only,
+            require_admin=require_admin,
+            ephemeral=ephemeral,
+            permissions=permissions,
+            cooldown=cooldown,
+            cooldown_rate=cooldown_rate,
+            cooldown_bucket=cooldown_bucket,
+            premium_required=premium_required,
+            command_name=command_name,
         )
-        callback.__signature__ = sig.replace(
-            parameters=[interaction_param] + user_params
-        )
-        return callback
 
     def _register_slash(
         self,
@@ -337,14 +178,15 @@ class _CommandsMixin(_MixinBase):
         parent: app_commands.Group | None = None,
         source_plugin: str | None = None,
     ) -> None:
-        """Register a callable as a slash command.
-
-        When *parent* is an ``app_commands.Group`` the command is added to
-        the group instead of the command tree (used by add_group).
-        """
-        guild = discord.Object(id=guild_id) if guild_id else None
-        callback = self._build_slash_callback(
+        """Register a callable as a slash command."""
+        register_slash(
+            self,
             func,
+            callback_builder=self._build_slash_callback,
+            context_factory=lambda interaction: Context(interaction),
+            name=name,
+            description=description,
+            guild_id=guild_id,
             guild_only=guild_only,
             require_admin=require_admin,
             ephemeral=ephemeral,
@@ -353,118 +195,26 @@ class _CommandsMixin(_MixinBase):
             cooldown_rate=cooldown_rate,
             cooldown_bucket=cooldown_bucket,
             premium_required=premium_required,
-            command_name=name,
-        )
-        autocomplete_handlers: dict[str, Callable] = {
-            **(autocomplete or {}),
-            **getattr(func, "_slash_autocomplete_handlers", {}),
-        }
-        if choices:
-            self._inject_choices(callback, choices)
-        cmd = app_commands.Command(
-            name=name,
-            description=description,
-            callback=callback,
+            autocomplete=autocomplete,
+            choices=choices,
             nsfw=nsfw,
             allowed_contexts=allowed_contexts,
             allowed_installs=allowed_installs,
-        )
-        for param_name, handler in autocomplete_handlers.items():
-            sig = inspect.signature(handler)
-            params = list(sig.parameters.values())
-            param_count = len(params)
-            
-            if param_count not in (1, 3):
-                plugin_info = f" in plugin {source_plugin}" if source_plugin else ""
-                raise TypeError(
-                    f"Invalid autocomplete signature for option {param_name!r} "
-                    f"of command {name!r}{plugin_info}. "
-                    f"Expected (current) or (ctx, current, options), got {sig}."
-                )
-            
-            expects_options = param_count == 3
-
-            def _make_autocomplete(_h: Callable, _expects_options: bool) -> Callable:
-                async def _ac(
-                    interaction: discord.Interaction,
-                    current: str,
-                ) -> list[app_commands.Choice]:
-                    ctx = Context(interaction)
-                    options = self._autocomplete_options(interaction)
-                    try:
-                        if _expects_options:
-                            results = await _h(ctx, current, options)
-                        else:
-                            results = await _h(current)
-                        return [app_commands.Choice(name=r, value=r) for r in results]
-                    except Exception as exc:
-                        plugin_instance = getattr(_h, "__self__", None)
-                        if plugin_instance is None and source_plugin:
-                            plugin_instance = next((p for p in self._plugins if getattr(p, "_instance_id", type(p).__name__) == source_plugin), None)
-                        await self._dispatch_framework_error(exc, ctx=ctx, plugin_instance=plugin_instance)
-                        return []
-
-                return _ac
-
-            _ac = _make_autocomplete(handler, expects_options)
-            cmd.autocomplete(param_name)(_ac)
-            self.registry.register_autocomplete(
-                name,
-                param_name,
-                handler,
-                source_plugin=source_plugin,
-                guild_id=guild_id,
-            )
-        if parent is not None:
-            parent.add_command(cmd)
-        else:
-            self.tree.add_command(cmd, guild=guild)
-        registry_name = f"{parent.name} {name}" if parent is not None else name
-        self.registry.register_slash_command(
-            registry_name,
-            func,
+            parent=parent,
             source_plugin=source_plugin,
-            guild_id=guild_id,
-            metadata={
-                "description": description,
-                "guild_only": guild_only,
-                "permissions": permissions,
-                "cooldown": cooldown,
-                "cooldown_rate": cooldown_rate,
-                "cooldown_bucket": cooldown_bucket,
-                "premium_required": premium_required,
-                "allowed_contexts": allowed_contexts,
-                "allowed_installs": allowed_installs,
-                "parent": getattr(parent, "name", None),
-            },
         )
-
-    # ── Subcommand groups ──────────────────────────────────────
 
     def add_group(self, group: "SlashGroup") -> None:
-        """Register a SlashGroup as a discord subcommand namespace.
-
-        Example::
-
-            class ModGroup(SlashGroup, name="mod", description="Moderation commands"):
-
-                @slash(description="Kick a member", permissions=["kick_members"])
-                async def kick(self, ctx, member: discord.Member):
-                    await member.kick()
-                    await ctx.respond(f"Kicked {member.display_name}.")
-
-            bot.add_group(ModGroup())
-        """
+        """Register a SlashGroup as a discord subcommand namespace."""
         from .group import SlashGroup
+
         if not isinstance(group, SlashGroup):
             raise TypeError(
                 f"expected a SlashGroup instance, got {type(group).__name__!r}"
             )
         if group in self._plugins:
-            raise ValueError(
-                f"{type(group).__name__} is already added to this bot."
-            )
-        group._bot = self  # type: ignore[assignment]  # ``self`` is the composed Bot at runtime
+            raise ValueError(f"{type(group).__name__} is already added to this bot.")
+        group._bot = self  # type: ignore[assignment]
         self._plugins.append(group)
 
         discord_group = app_commands.Group(
@@ -490,8 +240,6 @@ class _CommandsMixin(_MixinBase):
         for group in groups:
             self.add_group(group)
 
-    # ── Context menus ─────────────────────────────────────────
-
     def user_command(
         self,
         name: str | None = None,
@@ -501,11 +249,8 @@ class _CommandsMixin(_MixinBase):
         allowed_contexts: app_commands.AppCommandContext | None = None,
         allowed_installs: app_commands.AppInstallationType | None = None,
     ) -> Callable:
-        """Decorator that registers a right-click User context menu command.
+        """Decorator that registers a right-click User context menu command."""
 
-        The handler receives ``(ctx, member)`` where ``member`` is the
-        right-clicked user as a ``discord.Member | discord.User``.
-        """
         def decorator(func: Callable) -> Callable:
             self._register_context_menu(
                 func,
@@ -517,6 +262,7 @@ class _CommandsMixin(_MixinBase):
                 allowed_installs=allowed_installs,
             )
             return func
+
         return decorator
 
     def message_command(
@@ -528,11 +274,8 @@ class _CommandsMixin(_MixinBase):
         allowed_contexts: app_commands.AppCommandContext | None = None,
         allowed_installs: app_commands.AppInstallationType | None = None,
     ) -> Callable:
-        """Decorator that registers a right-click Message context menu command.
+        """Decorator that registers a right-click Message context menu command."""
 
-        The handler receives ``(ctx, message)`` where ``message`` is the
-        right-clicked ``discord.Message``.
-        """
         def decorator(func: Callable) -> Callable:
             self._register_context_menu(
                 func,
@@ -544,6 +287,7 @@ class _CommandsMixin(_MixinBase):
                 allowed_installs=allowed_installs,
             )
             return func
+
         return decorator
 
     def _register_context_menu(
@@ -558,81 +302,30 @@ class _CommandsMixin(_MixinBase):
         allowed_installs: app_commands.AppInstallationType | None = None,
         source_plugin: str | None = None,
     ) -> None:
-        """Build and register an app_commands.ContextMenu from a user-provided handler."""
-        guild = discord.Object(id=guild_id) if guild_id else None
-        sig = inspect.signature(func)
-        params = list(sig.parameters.values())
-        target_name = params[1].name if len(params) > 1 else "target"
-
-        if menu_type == discord.AppCommandType.user:
-            target_annotation: type = Union[discord.Member, discord.User]  # type: ignore[assignment]
-        else:
-            target_annotation = discord.Message
-
-        interaction_param = inspect.Parameter(
-            "interaction",
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=discord.Interaction,
-        )
-        target_param = inspect.Parameter(
-            target_name,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=target_annotation,
-        )
-
-        async def callback(interaction: discord.Interaction, target) -> None:
-            ctx = Context(interaction)
-            async def invoke() -> None:
-                await func(ctx, target)
-            await build_chain(ctx, invoke, self._middleware)()
-
-        callback.__signature__ = inspect.Signature(
-            parameters=[interaction_param, target_param]
-        )
-        menu = app_commands.ContextMenu(
+        """Build and register an app_commands.ContextMenu from a handler."""
+        register_context_menu(
+            self,
+            func,
+            context_factory=lambda interaction: Context(interaction),
+            chain_builder=lambda ctx, invoke, middleware: build_chain(
+                ctx,
+                invoke,
+                middleware,
+            ),
             name=name,
-            callback=callback,
-            type=menu_type,
+            menu_type=menu_type,
+            guild_id=guild_id,
             nsfw=nsfw,
             allowed_contexts=allowed_contexts,
             allowed_installs=allowed_installs,
-        )
-        self.tree.add_command(menu, guild=guild)
-        self.registry.register_context_menu(
-            name,
-            func,
             source_plugin=source_plugin,
-            guild_id=guild_id,
-            metadata={
-                "menu_type": menu_type.name,
-                "nsfw": nsfw,
-                "allowed_contexts": allowed_contexts,
-                "allowed_installs": allowed_installs,
-            },
         )
-        logger.debug("Registered context menu %r (type=%s)", name, menu_type.name)
 
     @staticmethod
     def _inject_choices(callback: Callable, choices: dict[str, list]) -> None:
         """Stamp discord.py's internal choices attribute onto a command callback."""
-        if not hasattr(callback, "__discord_app_commands_param_choices__"):
-            callback.__discord_app_commands_param_choices__ = {}
-        for param_name, values in choices.items():
-            callback.__discord_app_commands_param_choices__[param_name] = [
-                app_commands.Choice(name=str(v), value=v) for v in values
-            ]
+        inject_choices(callback, choices)
 
     @staticmethod
     def _autocomplete_options(interaction: discord.Interaction) -> dict[str, object]:
-        namespace = getattr(interaction, "namespace", None)
-        if namespace is not None:
-            try:
-                return dict(vars(namespace))
-            except TypeError:
-                pass  # namespace has no __dict__ (e.g. a slots-based fake); fall back to raw data
-        data = getattr(interaction, "data", None) or {}
-        options: dict[str, object] = {}
-        for item in data.get("options", []):
-            if "name" in item and "value" in item:
-                options[item["name"]] = item["value"]
-        return options
+        return autocomplete_options(interaction)

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -629,7 +629,7 @@ class _CommandsMixin(_MixinBase):
             try:
                 return dict(vars(namespace))
             except TypeError:
-                pass
+                pass  # namespace has no __dict__ (e.g. a slots-based fake); fall back to raw data
         data = getattr(interaction, "data", None) or {}
         options: dict[str, object] = {}
         for item in data.get("options", []):

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -183,7 +183,7 @@ class _CommandsMixin(_MixinBase):
             self,
             func,
             callback_builder=self._build_slash_callback,
-            context_factory=lambda interaction: Context(interaction),
+            context_factory=Context,
             name=name,
             description=description,
             guild_id=guild_id,

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -138,7 +138,7 @@ class _CommandsMixin(_MixinBase):
         return build_slash_callback(
             self,
             func,
-            context_factory=lambda interaction: Context(interaction),
+            context_factory=Context,
             chain_builder=lambda ctx, invoke, middleware: build_chain(
                 ctx,
                 invoke,

--- a/easycord/_bot_commands.py
+++ b/easycord/_bot_commands.py
@@ -138,7 +138,7 @@ class _CommandsMixin(_MixinBase):
         return build_slash_callback(
             self,
             func,
-            context_factory=Context,
+            context_factory=lambda interaction: Context(interaction),
             chain_builder=lambda ctx, invoke, middleware: build_chain(
                 ctx,
                 invoke,
@@ -183,7 +183,7 @@ class _CommandsMixin(_MixinBase):
             self,
             func,
             callback_builder=self._build_slash_callback,
-            context_factory=Context,
+            context_factory=lambda interaction: Context(interaction),
             name=name,
             description=description,
             guild_id=guild_id,

--- a/easycord/_bot_plugins.py
+++ b/easycord/_bot_plugins.py
@@ -8,8 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import discord
 
-from .tool_limits import RateLimit
-from .tools import ToolSafety
+from ._plugin_scanner import scan_plugin_methods
 
 if TYPE_CHECKING:
     from ._bot_base import _BotBase
@@ -45,146 +44,7 @@ class _PluginsMixin(_MixinBase):
         parent: an ``app_commands.Group`` — when supplied, slash commands are
         added to the group instead of the command tree (used by add_group).
         """
-        plugin_name = getattr(plugin, "_instance_id", str(id(plugin)))
-        standalone_autocomplete: dict[str, dict[str, Callable]] = {}
-        for _, method in _iter_methods(plugin):
-            if getattr(method, "_is_autocomplete", False):
-                standalone_autocomplete.setdefault(
-                    method._autocomplete_command,
-                    {},
-                )[method._autocomplete_option] = method
-
-        for _, method in _iter_methods(plugin):
-            if getattr(method, "_is_slash", False):
-                autocomplete_handlers = {
-                    **getattr(method, "_slash_autocomplete", {}),
-                    **standalone_autocomplete.get(method._slash_name, {}),
-                }
-                self._register_slash(
-                    method,
-                    name=method._slash_name,
-                    description=method._slash_desc,
-                    guild_id=method._slash_guild,
-                    guild_only=getattr(method, "_slash_guild_only", False),
-                    require_admin=getattr(method, "_slash_require_admin", False),
-                    ephemeral=getattr(method, "_slash_ephemeral", False),
-                    permissions=getattr(method, "_slash_permissions", None),
-                    cooldown=getattr(method, "_slash_cooldown", None),
-                    cooldown_rate=getattr(method, "_slash_cooldown_rate", 1),
-                    cooldown_bucket=getattr(method, "_slash_cooldown_bucket", "user"),
-                    premium_required=getattr(method, "_slash_premium_required", False),
-                    autocomplete=autocomplete_handlers,
-                    choices=getattr(method, "_slash_choices", None),
-                    nsfw=getattr(method, "_slash_nsfw", False),
-                    allowed_contexts=getattr(method, "_slash_allowed_contexts", None),
-                    allowed_installs=getattr(method, "_slash_allowed_installs", None),
-                    parent=parent,
-                    source_plugin=plugin_name,
-                )
-                for alias in getattr(method, "_slash_aliases", []):
-                    self._register_slash(
-                        method,
-                        name=alias,
-                        description=method._slash_desc,
-                        guild_id=method._slash_guild,
-                        guild_only=getattr(method, "_slash_guild_only", False),
-                        require_admin=getattr(method, "_slash_require_admin", False),
-                        ephemeral=getattr(method, "_slash_ephemeral", False),
-                        permissions=getattr(method, "_slash_permissions", None),
-                        cooldown=getattr(method, "_slash_cooldown", None),
-                        cooldown_rate=getattr(method, "_slash_cooldown_rate", 1),
-                        cooldown_bucket=getattr(method, "_slash_cooldown_bucket", "user"),
-                        premium_required=getattr(method, "_slash_premium_required", False),
-                        autocomplete=autocomplete_handlers,
-                        choices=getattr(method, "_slash_choices", None),
-                        nsfw=getattr(method, "_slash_nsfw", False),
-                        allowed_contexts=getattr(method, "_slash_allowed_contexts", None),
-                        allowed_installs=getattr(method, "_slash_allowed_installs", None),
-                        parent=parent,
-                        source_plugin=plugin_name,
-                    )
-            if getattr(method, "_is_command_error", False):
-                self._command_error_handlers[method._command_error_for] = method
-            if getattr(method, "_is_event", False):
-                self._event_handlers.setdefault(
-                    method._event_name, []
-                ).append(method)
-            if getattr(method, "_is_user_command", False):
-                self._register_context_menu(
-                    method,
-                    name=method._context_menu_name,
-                    menu_type=discord.AppCommandType.user,
-                    guild_id=method._context_menu_guild,
-                    nsfw=getattr(method, "_context_menu_nsfw", False),
-                    allowed_contexts=getattr(method, "_context_menu_allowed_contexts", None),
-                    allowed_installs=getattr(method, "_context_menu_allowed_installs", None),
-                    source_plugin=plugin_name,
-                )
-            if getattr(method, "_is_message_command", False):
-                self._register_context_menu(
-                    method,
-                    name=method._context_menu_name,
-                    menu_type=discord.AppCommandType.message,
-                    guild_id=method._context_menu_guild,
-                    nsfw=getattr(method, "_context_menu_nsfw", False),
-                    allowed_contexts=getattr(method, "_context_menu_allowed_contexts", None),
-                    allowed_installs=getattr(method, "_context_menu_allowed_installs", None),
-                    source_plugin=plugin_name,
-                )
-            if getattr(method, "_is_component", False):
-                custom_id = method._component_id
-                if getattr(method, "_component_scoped", True):
-                    custom_id = plugin.id(custom_id)
-                self._register_component_handler(
-                    custom_id,
-                    method,
-                    source_plugin=plugin_name,
-                    ttl=getattr(method, "_component_ttl", None),
-                )
-            if getattr(method, "_is_modal", False):
-                custom_id = method._modal_id
-                if getattr(method, "_modal_scoped", True):
-                    custom_id = plugin.id(custom_id)
-                self._register_modal_handler(custom_id, method, source_plugin=plugin_name)
-            if getattr(method, "_is_ai_tool", False):
-                tool_name = method._ai_tool_name
-                rate_limit = getattr(method, "_ai_tool_rate_limit", None)
-                rate_limit_obj = (
-                    RateLimit(max_calls=rate_limit[0], window_minutes=rate_limit[1])
-                    if rate_limit
-                    else None
-                )
-                safety = getattr(method, "_ai_tool_safety", ToolSafety.SAFE)
-                self.ai_tools[tool_name] = {
-                    "name": tool_name,
-                    "description": method._ai_tool_description,
-                    "func": method,
-                    "parameters": method._ai_tool_parameters,
-                    "safety": safety,
-                    "require_guild": getattr(method, "_ai_tool_require_guild", True),
-                    "require_admin": getattr(method, "_ai_tool_require_admin", False),
-                    "allowed_roles": getattr(method, "_ai_tool_allowed_roles", []),
-                    "allowed_users": getattr(method, "_ai_tool_allowed_users", []),
-                    "timeout_ms": getattr(method, "_ai_tool_timeout_ms", 5000),
-                    "rate_limit": rate_limit_obj,
-                }
-                if tool_name not in self.tool_registry._tools:
-                    self.tool_registry.register(
-                        name=tool_name,
-                        func=method,
-                        description=method._ai_tool_description,
-                        safety=safety,
-                        parameters=method._ai_tool_parameters,
-                        require_guild=getattr(method, "_ai_tool_require_guild", True),
-                        require_admin=getattr(method, "_ai_tool_require_admin", False),
-                        allowed_roles=getattr(method, "_ai_tool_allowed_roles", []),
-                        allowed_users=getattr(method, "_ai_tool_allowed_users", []),
-                        permissions=getattr(method, "_ai_tool_permissions", []),
-                        timeout_ms=getattr(method, "_ai_tool_timeout_ms", 5000),
-                        rate_limit=rate_limit_obj,
-                    )
-                if safety is ToolSafety.RESTRICTED:
-                    self.tool_registry.disable(tool_name)
+        scan_plugin_methods(self, plugin, iter_methods=_iter_methods, parent=parent)
 
     # ── Plugins ───────────────────────────────────────────────
 

--- a/easycord/_command_callbacks.py
+++ b/easycord/_command_callbacks.py
@@ -1,0 +1,181 @@
+"""Callback builders for Discord application commands."""
+from __future__ import annotations
+
+import inspect
+import time
+from typing import Any, Callable, cast
+
+import discord
+
+
+def build_slash_callback(
+    bot: Any,
+    func: Callable,
+    *,
+    context_factory: Callable[[discord.Interaction], Any],
+    chain_builder: Callable,
+    guild_only: bool = False,
+    require_admin: bool = False,
+    ephemeral: bool = False,
+    permissions: list[str] | None = None,
+    cooldown: float | None = None,
+    cooldown_rate: int = 1,
+    cooldown_bucket: str = "user",
+    premium_required: bool = False,
+    command_name: str | None = None,
+) -> Callable:
+    """Build a discord.py-compatible slash callback."""
+    sig = inspect.signature(func)
+    user_params = list(sig.parameters.values())[1:]
+    cooldown_last_used: dict[int, list[float]] = {}
+    if cooldown is not None and cooldown_rate < 1:
+        raise ValueError("cooldown_rate must be at least 1")
+    if cooldown_bucket not in {"user", "guild", "global"}:
+        raise ValueError("cooldown_bucket must be 'user', 'guild', or 'global'")
+
+    effective_permissions = list(permissions or [])
+    if require_admin and "administrator" not in effective_permissions:
+        effective_permissions.append("administrator")
+
+    async def callback(interaction: discord.Interaction, **kwargs) -> None:
+        ctx = context_factory(interaction)
+        if ephemeral:
+            ctx._force_ephemeral = True
+
+        async def invoke() -> None:
+            if guild_only and not ctx.guild:
+                await ctx.respond(
+                    ctx.t(
+                        "errors.guild_only",
+                        default="This command can only be used inside a server.",
+                    ),
+                    ephemeral=True,
+                )
+                return
+            if effective_permissions:
+                if not ctx.guild:
+                    await ctx.respond(
+                        ctx.t(
+                            "errors.guild_only",
+                            default="This command can only be used inside a server.",
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+                member = ctx.guild.get_member(ctx.user.id)
+                if not member:
+                    await ctx.respond(
+                        ctx.t(
+                            "errors.permissions_unverified",
+                            default="Could not verify your permissions.",
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+                missing = [
+                    p
+                    for p in effective_permissions
+                    if not getattr(member.guild_permissions, p, False)
+                ]
+                if missing:
+                    await ctx.respond(
+                        ctx.t(
+                            "errors.permissions_missing",
+                            default="You need the following permission(s): {permissions}.",
+                            permissions=", ".join(missing),
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+            if premium_required and not ctx.entitlements:
+                await ctx.respond(
+                    ctx.t(
+                        "errors.premium_required",
+                        default="This command requires an active premium subscription.",
+                    ),
+                    ephemeral=True,
+                )
+                return
+            if cooldown is not None:
+                if cooldown_bucket == "guild":
+                    bucket_key = ctx.guild.id if ctx.guild else ctx.user.id
+                elif cooldown_bucket == "global":
+                    bucket_key = 0
+                else:
+                    bucket_key = ctx.user.id
+                now = time.monotonic()
+                used_at = [
+                    ts
+                    for ts in cooldown_last_used.get(bucket_key, [])
+                    if now - ts < cooldown
+                ]
+                if len(used_at) >= cooldown_rate:
+                    remaining = cooldown - (now - used_at[0])
+                    await ctx.respond(
+                        ctx.t(
+                            "errors.cooldown",
+                            default="This command is on cooldown. Try again in {seconds:.1f}s.",
+                            seconds=remaining,
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+                used_at.append(now)
+                cooldown_last_used[bucket_key] = used_at
+            try:
+                await func(ctx, **kwargs)
+            except Exception as exc:
+                per_cmd = (
+                    getattr(bot, "_command_error_handlers", {}).get(command_name)
+                    if command_name
+                    else None
+                )
+                if per_cmd is not None:
+                    await per_cmd(ctx, exc)
+                    return
+                plugin = getattr(func, "__self__", None)
+                if plugin is not None:
+                    from .plugin import Plugin as _Plugin
+
+                    if isinstance(plugin, _Plugin):
+                        plugin_on_error = type(plugin).on_error
+                        base_on_error = _Plugin.on_error
+                        if plugin_on_error is not base_on_error:
+                            await plugin.on_error(ctx, exc)
+                            return
+                if bot._error_handler is not None:
+                    await bot._error_handler(ctx, exc)
+                else:
+                    raise
+
+        await chain_builder(ctx, invoke, bot._middleware)()
+
+    interaction_param = inspect.Parameter(
+        "interaction",
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=discord.Interaction,
+    )
+    cast(Any, callback).__signature__ = sig.replace(
+        parameters=[interaction_param] + user_params
+    )
+    return callback
+
+
+def build_context_menu_callback(
+    bot: Any,
+    func: Callable,
+    *,
+    context_factory: Callable[[discord.Interaction], Any],
+    chain_builder: Callable,
+) -> Callable:
+    """Build the callback wrapper used by app command context menus."""
+
+    async def callback(interaction: discord.Interaction, target) -> None:
+        ctx = context_factory(interaction)
+
+        async def invoke() -> None:
+            await func(ctx, target)
+
+        await chain_builder(ctx, invoke, bot._middleware)()
+
+    return callback

--- a/easycord/_command_registration.py
+++ b/easycord/_command_registration.py
@@ -1,0 +1,267 @@
+"""Registration helpers for Discord application commands."""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Callable, Union
+
+import discord
+from discord import app_commands
+
+from ._command_callbacks import build_context_menu_callback
+
+logger = logging.getLogger("easycord")
+
+
+def register_slash(
+    bot: object,
+    func: Callable,
+    *,
+    callback_builder: Callable[..., Callable],
+    context_factory: Callable[[discord.Interaction], object],
+    name: str,
+    description: str,
+    guild_id: int | None,
+    guild_only: bool = False,
+    require_admin: bool = False,
+    ephemeral: bool = False,
+    permissions: list[str] | None = None,
+    cooldown: float | None = None,
+    cooldown_rate: int = 1,
+    cooldown_bucket: str = "user",
+    premium_required: bool = False,
+    autocomplete: dict[str, Callable] | None = None,
+    choices: dict[str, list] | None = None,
+    nsfw: bool = False,
+    allowed_contexts: app_commands.AppCommandContext | None = None,
+    allowed_installs: app_commands.AppInstallationType | None = None,
+    parent: app_commands.Group | None = None,
+    source_plugin: str | None = None,
+) -> None:
+    """Register a callable as a slash command."""
+    guild = discord.Object(id=guild_id) if guild_id else None
+    callback = callback_builder(
+        func,
+        guild_only=guild_only,
+        require_admin=require_admin,
+        ephemeral=ephemeral,
+        permissions=permissions,
+        cooldown=cooldown,
+        cooldown_rate=cooldown_rate,
+        cooldown_bucket=cooldown_bucket,
+        premium_required=premium_required,
+        command_name=name,
+    )
+    autocomplete_handlers: dict[str, Callable] = {
+        **(autocomplete or {}),
+        **getattr(func, "_slash_autocomplete_handlers", {}),
+    }
+    if choices:
+        inject_choices(callback, choices)
+    cmd = app_commands.Command(
+        name=name,
+        description=description,
+        callback=callback,
+        nsfw=nsfw,
+        allowed_contexts=allowed_contexts,
+        allowed_installs=allowed_installs,
+    )
+    for param_name, handler in autocomplete_handlers.items():
+        _register_autocomplete_handler(
+            bot,
+            cmd,
+            name=name,
+            param_name=param_name,
+            handler=handler,
+            source_plugin=source_plugin,
+            guild_id=guild_id,
+            context_factory=context_factory,
+        )
+    if parent is not None:
+        parent.add_command(cmd)
+    else:
+        bot.tree.add_command(cmd, guild=guild)
+    registry_name = f"{parent.name} {name}" if parent is not None else name
+    bot.registry.register_slash_command(
+        registry_name,
+        func,
+        source_plugin=source_plugin,
+        guild_id=guild_id,
+        metadata={
+            "description": description,
+            "guild_only": guild_only,
+            "permissions": permissions,
+            "cooldown": cooldown,
+            "cooldown_rate": cooldown_rate,
+            "cooldown_bucket": cooldown_bucket,
+            "premium_required": premium_required,
+            "allowed_contexts": allowed_contexts,
+            "allowed_installs": allowed_installs,
+            "parent": getattr(parent, "name", None),
+        },
+    )
+
+
+def _register_autocomplete_handler(
+    bot: object,
+    cmd: app_commands.Command,
+    *,
+    name: str,
+    param_name: str,
+    handler: Callable,
+    source_plugin: str | None,
+    guild_id: int | None,
+    context_factory: Callable[[discord.Interaction], object],
+) -> None:
+    sig = inspect.signature(handler)
+    params = list(sig.parameters.values())
+    param_count = len(params)
+
+    if param_count not in (1, 3):
+        plugin_info = f" in plugin {source_plugin}" if source_plugin else ""
+        raise TypeError(
+            f"Invalid autocomplete signature for option {param_name!r} "
+            f"of command {name!r}{plugin_info}. "
+            f"Expected (current) or (ctx, current, options), got {sig}."
+        )
+
+    expects_options = param_count == 3
+
+    def _make_autocomplete(_h: Callable, _expects_options: bool) -> Callable:
+        async def _ac(
+            interaction: discord.Interaction,
+            current: str,
+        ) -> list[app_commands.Choice]:
+            ctx = context_factory(interaction)
+            options = autocomplete_options(interaction)
+            try:
+                if _expects_options:
+                    results = await _h(ctx, current, options)
+                else:
+                    results = await _h(current)
+                return [app_commands.Choice(name=r, value=r) for r in results]
+            except Exception as exc:
+                plugin_instance = getattr(_h, "__self__", None)
+                if plugin_instance is None and source_plugin:
+                    plugin_instance = next(
+                        (
+                            p
+                            for p in bot._plugins
+                            if getattr(p, "_instance_id", type(p).__name__)
+                            == source_plugin
+                        ),
+                        None,
+                    )
+                await bot._dispatch_framework_error(
+                    exc,
+                    ctx=ctx,
+                    plugin_instance=plugin_instance,
+                )
+                return []
+
+        return _ac
+
+    ac_callback = _make_autocomplete(handler, expects_options)
+    cmd.autocomplete(param_name)(ac_callback)
+    bot.registry.register_autocomplete(
+        name,
+        param_name,
+        handler,
+        source_plugin=source_plugin,
+        guild_id=guild_id,
+    )
+
+
+def register_context_menu(
+    bot: object,
+    func: Callable,
+    *,
+    context_factory: Callable[[discord.Interaction], object],
+    chain_builder: Callable,
+    name: str,
+    menu_type: discord.AppCommandType,
+    guild_id: int | None,
+    nsfw: bool = False,
+    allowed_contexts: app_commands.AppCommandContext | None = None,
+    allowed_installs: app_commands.AppInstallationType | None = None,
+    source_plugin: str | None = None,
+) -> None:
+    """Build and register an app_commands.ContextMenu."""
+    guild = discord.Object(id=guild_id) if guild_id else None
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())
+    target_name = params[1].name if len(params) > 1 else "target"
+
+    if menu_type == discord.AppCommandType.user:
+        target_annotation: type = Union[discord.Member, discord.User]  # type: ignore[assignment]
+    else:
+        target_annotation = discord.Message
+
+    interaction_param = inspect.Parameter(
+        "interaction",
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=discord.Interaction,
+    )
+    target_param = inspect.Parameter(
+        target_name,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=target_annotation,
+    )
+
+    callback = build_context_menu_callback(
+        bot,
+        func,
+        context_factory=context_factory,
+        chain_builder=chain_builder,
+    )
+    callback.__signature__ = inspect.Signature(
+        parameters=[interaction_param, target_param]
+    )
+    menu = app_commands.ContextMenu(
+        name=name,
+        callback=callback,
+        type=menu_type,
+        nsfw=nsfw,
+        allowed_contexts=allowed_contexts,
+        allowed_installs=allowed_installs,
+    )
+    bot.tree.add_command(menu, guild=guild)
+    bot.registry.register_context_menu(
+        name,
+        func,
+        source_plugin=source_plugin,
+        guild_id=guild_id,
+        metadata={
+            "menu_type": menu_type.name,
+            "nsfw": nsfw,
+            "allowed_contexts": allowed_contexts,
+            "allowed_installs": allowed_installs,
+        },
+    )
+    logger.debug("Registered context menu %r (type=%s)", name, menu_type.name)
+
+
+def inject_choices(callback: Callable, choices: dict[str, list]) -> None:
+    """Stamp discord.py's internal choices attribute onto a command callback."""
+    if not hasattr(callback, "__discord_app_commands_param_choices__"):
+        callback.__discord_app_commands_param_choices__ = {}
+    for param_name, values in choices.items():
+        callback.__discord_app_commands_param_choices__[param_name] = [
+            app_commands.Choice(name=str(v), value=v) for v in values
+        ]
+
+
+def autocomplete_options(interaction: discord.Interaction) -> dict[str, object]:
+    """Extract current autocomplete option values from a Discord interaction."""
+    namespace = getattr(interaction, "namespace", None)
+    if namespace is not None:
+        try:
+            return dict(vars(namespace))
+        except TypeError:
+            pass
+    data = getattr(interaction, "data", None) or {}
+    options: dict[str, object] = {}
+    for item in data.get("options", []):
+        if "name" in item and "value" in item:
+            options[item["name"]] = item["value"]
+    return options

--- a/easycord/_i18n_diagnostics.py
+++ b/easycord/_i18n_diagnostics.py
@@ -1,0 +1,92 @@
+"""Diagnostic helpers for EasyCord localization."""
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger("easycord.i18n")
+
+
+class DiagnosticMode(Enum):
+    """Localization diagnostic modes."""
+
+    SILENT = "silent"
+    WARN = "warn"
+    STRICT = "strict"
+
+
+class LocalizationDiagnostics:
+    """Track missing keys and invalid placeholders with deduplication."""
+
+    def __init__(self, mode: DiagnosticMode = DiagnosticMode.SILENT):
+        self.mode = mode
+        self._seen_missing: set[tuple[str, str]] = set()
+        self._seen_placeholder: set[tuple[str, str]] = set()
+        self._missing_count = 0
+        self._placeholder_count = 0
+
+    def report_missing_key(
+        self,
+        key: str,
+        locale: str,
+        fallback_locale: str | None = None,
+    ) -> None:
+        """Report a missing translation key."""
+        if self.mode == DiagnosticMode.SILENT:
+            return
+
+        fallback_msg = f" (fallback: {fallback_locale})" if fallback_locale else ""
+        message = f"Missing key '{key}' in locale '{locale}'{fallback_msg}"
+
+        if self.mode == DiagnosticMode.STRICT:
+            self._missing_count += 1
+            raise KeyError(message)
+        if self.mode == DiagnosticMode.WARN:
+            cache_key = (key, locale)
+            if cache_key in self._seen_missing:
+                return
+            self._seen_missing.add(cache_key)
+            self._missing_count += 1
+            logger.warning(message)
+
+    def report_invalid_placeholder(
+        self,
+        key: str,
+        template: str,
+        placeholder: str,
+    ) -> None:
+        """Report a template with missing/invalid placeholders."""
+        if self.mode == DiagnosticMode.SILENT:
+            return
+
+        message = (
+            f"Invalid placeholder in '{key}': template has '{placeholder}' "
+            "but value not provided"
+        )
+
+        if self.mode == DiagnosticMode.STRICT:
+            self._placeholder_count += 1
+            raise KeyError(message)
+        if self.mode == DiagnosticMode.WARN:
+            cache_key = (key, placeholder)
+            if cache_key in self._seen_placeholder:
+                return
+            self._seen_placeholder.add(cache_key)
+            self._placeholder_count += 1
+            logger.warning(message)
+
+    def missing_keys_summary(self) -> dict[str, int]:
+        """Return summary of missing keys."""
+        return {
+            "total_missing": self._missing_count,
+            "total_placeholders": self._placeholder_count,
+            "unique_missing": len(self._seen_missing),
+            "unique_placeholders": len(self._seen_placeholder),
+        }
+
+    def reset(self) -> None:
+        """Reset all diagnostics."""
+        self._seen_missing.clear()
+        self._seen_placeholder.clear()
+        self._missing_count = 0
+        self._placeholder_count = 0

--- a/easycord/_i18n_locale.py
+++ b/easycord/_i18n_locale.py
@@ -28,6 +28,8 @@ def detect_os_locale() -> str | None:
                 return _normalize_locale(f"{lang}_{country}")
             return _normalize_locale(lang)
     except (AttributeError, ValueError):
+        # getdefaultlocale() raises AttributeError on some platforms and ValueError
+        # on malformed locale env vars; fall back silently so callers get None.
         pass
     return None
 

--- a/easycord/_i18n_locale.py
+++ b/easycord/_i18n_locale.py
@@ -1,0 +1,105 @@
+"""Locale helpers for EasyCord localization."""
+from __future__ import annotations
+
+import locale as stdlib_locale
+from typing import Any
+
+
+def _normalize_locale(locale: Any) -> str | None:
+    """Normalize locale string to standard format (en-US, not en_US)."""
+    if locale is None:
+        return None
+    if hasattr(locale, "value"):
+        locale = locale.value
+    text = str(locale).strip()
+    if not text:
+        return None
+    return text.replace("_", "-")
+
+
+def detect_os_locale() -> str | None:
+    """Detect the system's locale preference."""
+    try:
+        system_locale = stdlib_locale.getdefaultlocale()
+        if system_locale and system_locale[0]:
+            lang = system_locale[0]
+            country = system_locale[1]
+            if country:
+                return _normalize_locale(f"{lang}_{country}")
+            return _normalize_locale(lang)
+    except (AttributeError, ValueError):
+        pass
+    return None
+
+
+def is_valid_locale(locale: str) -> bool:
+    """Check if a locale tag has a supported BCP 47-like shape."""
+    if not locale or not isinstance(locale, str):
+        return False
+
+    parts = locale.split("-")
+    if not parts[0] or len(parts[0]) < 2 or len(parts[0]) > 3:
+        return False
+
+    if len(parts) == 1:
+        return True
+
+    second = parts[1]
+    if not second:
+        return False
+
+    if len(second) == 4:
+        if len(parts) == 2:
+            return True
+        if len(parts) == 3:
+            third = parts[2]
+            return len(third) == 2
+        return False
+
+    if len(second) == 2:
+        return len(parts) == 2
+
+    return False
+
+
+def build_locale_chain(
+    default_locale: str,
+    *,
+    locale: Any = None,
+    guild_locale: Any = None,
+) -> tuple[tuple[str | None, str | None, bool], list[str]]:
+    """Return the cache key and fallback chain for a locale lookup."""
+    normalized_locale = _normalize_locale(locale)
+    normalized_guild = _normalize_locale(guild_locale)
+
+    if normalized_locale is None and normalized_guild is None:
+        cache_key = (None, None, True)
+        candidates = [default_locale]
+    else:
+        cache_key = (normalized_locale, normalized_guild, False)
+        candidates = [normalized_locale, normalized_guild, default_locale]
+
+    chain: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        parts = candidate.split("-")
+        for index in range(len(parts), 0, -1):
+            value = "-".join(parts[:index])
+            if value not in chain:
+                chain.append(value)
+    return cache_key, chain
+
+
+def build_preferred_locale_chain(*locales: Any) -> list[str]:
+    """Build a locale chain without adding the default locale."""
+    chain: list[str] = []
+    for candidate in (_normalize_locale(locale) for locale in locales):
+        if not candidate:
+            continue
+        parts = candidate.split("-")
+        for index in range(len(parts), 0, -1):
+            value = "-".join(parts[:index])
+            if value not in chain:
+                chain.append(value)
+    return chain

--- a/easycord/_i18n_validation.py
+++ b/easycord/_i18n_validation.py
@@ -1,0 +1,72 @@
+"""Translation validation report helpers."""
+from __future__ import annotations
+
+
+class TranslationValidationReport:
+    """Report from translation completeness validation."""
+
+    def __init__(self, base_locale: str):
+        self.base_locale = base_locale
+        self.results: dict[str, dict] = {}
+
+    def add_locale(
+        self,
+        locale: str,
+        missing_keys: list[str],
+        orphaned_keys: list[str],
+        coverage: float,
+    ) -> None:
+        """Add validation results for a locale."""
+        self.results[locale] = {
+            "missing_keys": sorted(missing_keys),
+            "orphaned_keys": sorted(orphaned_keys),
+            "coverage": coverage,
+            "total_missing": len(missing_keys),
+            "total_orphaned": len(orphaned_keys),
+        }
+
+    def is_valid(self) -> bool:
+        """Check if all locales are fully translated."""
+        return all(
+            result["total_missing"] == 0 for result in self.results.values()
+        )
+
+    def summary(self) -> dict:
+        """Return summary statistics."""
+        total_locales = len(self.results)
+        fully_translated = sum(
+            1 for r in self.results.values() if r["total_missing"] == 0
+        )
+        return {
+            "base_locale": self.base_locale,
+            "total_locales": total_locales,
+            "fully_translated": fully_translated,
+            "coverage_by_locale": {
+                locale: result["coverage"]
+                for locale, result in self.results.items()
+            },
+        }
+
+    def report_text(self) -> str:
+        """Return human-readable report."""
+        lines = [f"Translation Validation Report (base: {self.base_locale})"]
+        lines.append("")
+
+        for locale in sorted(self.results.keys()):
+            result = self.results[locale]
+            status = "✓" if result["total_missing"] == 0 else "✗"
+            lines.append(
+                f"{status} {locale}: {result['coverage']:.1%} coverage "
+                f"({result['total_missing']} missing)"
+            )
+            if result["missing_keys"]:
+                lines.append(
+                    f"  Missing: {', '.join(result['missing_keys'][:3])}"
+                    f"{'...' if len(result['missing_keys']) > 3 else ''}"
+                )
+            if result["orphaned_keys"]:
+                lines.append(
+                    f"  Orphaned: {', '.join(result['orphaned_keys'][:3])}"
+                    f"{'...' if len(result['orphaned_keys']) > 3 else ''}"
+                )
+        return "\n".join(lines)

--- a/easycord/_plugin_scanner.py
+++ b/easycord/_plugin_scanner.py
@@ -1,0 +1,180 @@
+"""Plugin method scanning and registration helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, cast
+
+import discord
+
+from .tool_limits import RateLimit
+from .tools import ToolSafety
+
+
+def scan_plugin_methods(
+    bot: object,
+    plugin: object,
+    *,
+    iter_methods: Callable[[object], list[tuple[str, Any]]],
+    parent=None,
+) -> None:
+    """Register decorated plugin methods on *bot*."""
+    plugin_name = getattr(plugin, "_instance_id", str(id(plugin)))
+    methods = iter_methods(plugin)
+    standalone_autocomplete = _collect_standalone_autocomplete(methods)
+
+    for _, method in methods:
+        if getattr(method, "_is_slash", False):
+            _register_slash_methods(
+                bot,
+                method,
+                plugin_name=plugin_name,
+                standalone_autocomplete=standalone_autocomplete,
+                parent=parent,
+            )
+        if getattr(method, "_is_command_error", False):
+            bot._command_error_handlers[method._command_error_for] = method
+        if getattr(method, "_is_event", False):
+            bot._event_handlers.setdefault(method._event_name, []).append(method)
+        if getattr(method, "_is_user_command", False):
+            _register_context_menu(
+                bot,
+                method,
+                plugin_name=plugin_name,
+                menu_type=discord.AppCommandType.user,
+            )
+        if getattr(method, "_is_message_command", False):
+            _register_context_menu(
+                bot,
+                method,
+                plugin_name=plugin_name,
+                menu_type=discord.AppCommandType.message,
+            )
+        if getattr(method, "_is_component", False):
+            custom_id = method._component_id
+            if getattr(method, "_component_scoped", True):
+                custom_id = plugin.id(custom_id)
+            bot._register_component_handler(
+                custom_id,
+                method,
+                source_plugin=plugin_name,
+                ttl=getattr(method, "_component_ttl", None),
+            )
+        if getattr(method, "_is_modal", False):
+            custom_id = method._modal_id
+            if getattr(method, "_modal_scoped", True):
+                custom_id = plugin.id(custom_id)
+            bot._register_modal_handler(custom_id, method, source_plugin=plugin_name)
+        if getattr(method, "_is_ai_tool", False):
+            _register_ai_tool(bot, method)
+
+
+def _collect_standalone_autocomplete(
+    methods: list[tuple[str, Any]],
+) -> dict[str, dict[str, Callable]]:
+    standalone_autocomplete: dict[str, dict[str, Callable]] = {}
+    for _, method in methods:
+        if getattr(method, "_is_autocomplete", False):
+            standalone_autocomplete.setdefault(
+                method._autocomplete_command,
+                {},
+            )[method._autocomplete_option] = method
+    return standalone_autocomplete
+
+
+def _register_slash_methods(
+    bot: object,
+    method: Callable,
+    *,
+    plugin_name: str,
+    standalone_autocomplete: dict[str, dict[str, Callable]],
+    parent,
+) -> None:
+    autocomplete_handlers = {
+        **getattr(method, "_slash_autocomplete", {}),
+        **standalone_autocomplete.get(method._slash_name, {}),
+    }
+    for command_name in [method._slash_name] + list(
+        getattr(method, "_slash_aliases", [])
+    ):
+        bot._register_slash(
+            method,
+            name=command_name,
+            description=method._slash_desc,
+            guild_id=method._slash_guild,
+            guild_only=getattr(method, "_slash_guild_only", False),
+            require_admin=getattr(method, "_slash_require_admin", False),
+            ephemeral=getattr(method, "_slash_ephemeral", False),
+            permissions=getattr(method, "_slash_permissions", None),
+            cooldown=getattr(method, "_slash_cooldown", None),
+            cooldown_rate=getattr(method, "_slash_cooldown_rate", 1),
+            cooldown_bucket=getattr(method, "_slash_cooldown_bucket", "user"),
+            premium_required=getattr(method, "_slash_premium_required", False),
+            autocomplete=autocomplete_handlers,
+            choices=getattr(method, "_slash_choices", None),
+            nsfw=getattr(method, "_slash_nsfw", False),
+            allowed_contexts=getattr(method, "_slash_allowed_contexts", None),
+            allowed_installs=getattr(method, "_slash_allowed_installs", None),
+            parent=parent,
+            source_plugin=plugin_name,
+        )
+
+
+def _register_context_menu(
+    bot: object,
+    method: Callable,
+    *,
+    plugin_name: str,
+    menu_type: discord.AppCommandType,
+) -> None:
+    bot._register_context_menu(
+        method,
+        name=method._context_menu_name,
+        menu_type=menu_type,
+        guild_id=method._context_menu_guild,
+        nsfw=getattr(method, "_context_menu_nsfw", False),
+        allowed_contexts=getattr(method, "_context_menu_allowed_contexts", None),
+        allowed_installs=getattr(method, "_context_menu_allowed_installs", None),
+        source_plugin=plugin_name,
+    )
+
+
+def _register_ai_tool(bot: object, method: Callable) -> None:
+    tool_name = cast(str, getattr(method, "_ai_tool_name"))
+    description = cast(str, getattr(method, "_ai_tool_description"))
+    parameters = cast(dict[str, Any], getattr(method, "_ai_tool_parameters"))
+    rate_limit = getattr(method, "_ai_tool_rate_limit", None)
+    rate_limit_obj = (
+        RateLimit(max_calls=rate_limit[0], window_minutes=rate_limit[1])
+        if rate_limit
+        else None
+    )
+    safety = cast(ToolSafety, getattr(method, "_ai_tool_safety", ToolSafety.SAFE))
+    bot.ai_tools[tool_name] = {
+        "name": tool_name,
+        "description": description,
+        "func": method,
+        "parameters": parameters,
+        "safety": safety,
+        "require_guild": getattr(method, "_ai_tool_require_guild", True),
+        "require_admin": getattr(method, "_ai_tool_require_admin", False),
+        "allowed_roles": getattr(method, "_ai_tool_allowed_roles", []),
+        "allowed_users": getattr(method, "_ai_tool_allowed_users", []),
+        "timeout_ms": getattr(method, "_ai_tool_timeout_ms", 5000),
+        "rate_limit": rate_limit_obj,
+    }
+    if tool_name not in bot.tool_registry._tools:
+        bot.tool_registry.register(
+            name=tool_name,
+            func=method,
+            description=description,
+            safety=safety,
+            parameters=parameters,
+            require_guild=getattr(method, "_ai_tool_require_guild", True),
+            require_admin=getattr(method, "_ai_tool_require_admin", False),
+            allowed_roles=getattr(method, "_ai_tool_allowed_roles", []),
+            allowed_users=getattr(method, "_ai_tool_allowed_users", []),
+            permissions=getattr(method, "_ai_tool_permissions", []),
+            timeout_ms=getattr(method, "_ai_tool_timeout_ms", 5000),
+            rate_limit=rate_limit_obj,
+        )
+    if safety is ToolSafety.RESTRICTED:
+        bot.tool_registry.disable(tool_name)

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -262,7 +262,7 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
                 mem = process.memory_info().rss / (1024 * 1024)
                 embed.add_field(name="Memory", value=f"{mem:.1f} MB")
             except ImportError:
-                pass
+                pass  # psutil is an optional dependency; skip the memory field if missing
 
             registry = self.registry.grouped()
             counts = [f"{k.title()}: {len(v)}" for k, v in registry.items()]

--- a/easycord/helpers/config.py
+++ b/easycord/helpers/config.py
@@ -49,8 +49,8 @@ class ConfigHelpers:
                         cfg_obj = await store.load(guild_id)
                         cfg = cfg_obj.get_other("config") or {}
                         results[guild_id] = cfg
-                    except (ValueError, Exception):
-                        pass
+                    except Exception:
+                        pass  # skip files with a non-numeric name or unreadable/corrupt config
 
         return results
 

--- a/easycord/helpers/tools.py
+++ b/easycord/helpers/tools.py
@@ -30,12 +30,13 @@ class ToolHelpers:
             description = tool_config.get("description")
             safety = tool_config.get("safety")
 
-            if (
-                not isinstance(name, str)
-                or not callable(func)
-                or not isinstance(description, str)
-                or not isinstance(safety, ToolSafety)
-            ):
+            if not isinstance(name, str) or not callable(func) or not isinstance(description, str):
+                continue
+            if safety is not None and not isinstance(safety, ToolSafety):
+                raise TypeError(
+                    f"safety must be a ToolSafety enum member, got {type(safety).__name__!r}"
+                )
+            if not isinstance(safety, ToolSafety):
                 continue
 
             registry.register(

--- a/easycord/helpers/tools.py
+++ b/easycord/helpers/tools.py
@@ -1,9 +1,10 @@
 """Tool registry helper shortcuts."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
 
-from easycord.tools import ToolDef, ToolRegistry
+from easycord.tools import ToolDef, ToolRegistry, ToolSafety
 
 if TYPE_CHECKING:
     pass
@@ -29,12 +30,17 @@ class ToolHelpers:
             description = tool_config.get("description")
             safety = tool_config.get("safety")
 
-            if not all([name, func, description, safety]):
+            if (
+                not isinstance(name, str)
+                or not callable(func)
+                or not isinstance(description, str)
+                or not isinstance(safety, ToolSafety)
+            ):
                 continue
 
             registry.register(
                 name=name,
-                func=func,
+                func=cast(Callable[..., Any], func),
                 description=description,
                 safety=safety,
                 parameters=tool_config.get("parameters"),

--- a/easycord/i18n.py
+++ b/easycord/i18n.py
@@ -1,205 +1,23 @@
 """Lightweight localization helpers for EasyCord."""
 from __future__ import annotations
 
-import locale as stdlib_locale
 import logging
 from collections.abc import Mapping
-from enum import Enum
 from typing import Callable
 from typing import Any
 
+from ._i18n_diagnostics import DiagnosticMode, LocalizationDiagnostics
+from ._i18n_locale import (
+    _normalize_locale,
+    build_locale_chain,
+    build_preferred_locale_chain,
+    detect_os_locale,
+    is_valid_locale,
+)
+from ._i18n_validation import TranslationValidationReport
+
 logger = logging.getLogger("easycord.i18n")
 trace_logger = logging.getLogger("easycord.i18n.trace")
-
-
-class DiagnosticMode(Enum):
-    """Localization diagnostic modes."""
-    SILENT = "silent"       # No warnings, no tracking
-    WARN = "warn"           # Deduplicated warnings to logger
-    STRICT = "strict"       # Raise exceptions on missing keys
-
-
-class TranslationValidationReport:
-    """Report from translation completeness validation."""
-
-    def __init__(self, base_locale: str):
-        self.base_locale = base_locale
-        self.results: dict[str, dict] = {}
-
-    def add_locale(
-        self,
-        locale: str,
-        missing_keys: list[str],
-        orphaned_keys: list[str],
-        coverage: float,
-    ) -> None:
-        """Add validation results for a locale."""
-        self.results[locale] = {
-            "missing_keys": sorted(missing_keys),
-            "orphaned_keys": sorted(orphaned_keys),
-            "coverage": coverage,
-            "total_missing": len(missing_keys),
-            "total_orphaned": len(orphaned_keys),
-        }
-
-    def is_valid(self) -> bool:
-        """Check if all locales are fully translated."""
-        return all(
-            result["total_missing"] == 0 for result in self.results.values()
-        )
-
-    def summary(self) -> dict:
-        """Return summary statistics."""
-        total_locales = len(self.results)
-        fully_translated = sum(
-            1 for r in self.results.values() if r["total_missing"] == 0
-        )
-        return {
-            "base_locale": self.base_locale,
-            "total_locales": total_locales,
-            "fully_translated": fully_translated,
-            "coverage_by_locale": {
-                locale: result["coverage"] for locale, result in self.results.items()
-            },
-        }
-
-    def report_text(self) -> str:
-        """Return human-readable report."""
-        lines = [f"Translation Validation Report (base: {self.base_locale})"]
-        lines.append("")
-
-        for locale in sorted(self.results.keys()):
-            result = self.results[locale]
-            status = "✓" if result["total_missing"] == 0 else "✗"
-            lines.append(
-                f"{status} {locale}: {result['coverage']:.1%} coverage "
-                f"({result['total_missing']} missing)"
-            )
-            if result["missing_keys"]:
-                lines.append(
-                    f"  Missing: {', '.join(result['missing_keys'][:3])}"
-                    f"{'...' if len(result['missing_keys']) > 3 else ''}"
-                )
-            if result["orphaned_keys"]:
-                lines.append(
-                    f"  Orphaned: {', '.join(result['orphaned_keys'][:3])}"
-                    f"{'...' if len(result['orphaned_keys']) > 3 else ''}"
-                )
-        return "\n".join(lines)
-
-
-class LocalizationDiagnostics:
-    """Track missing keys and invalid placeholders with deduplication."""
-
-    def __init__(self, mode: DiagnosticMode = DiagnosticMode.SILENT):
-        self.mode = mode
-        self._seen_missing: set[tuple[str, str]] = set()
-        self._seen_placeholder: set[tuple[str, str]] = set()
-        self._missing_count = 0
-        self._placeholder_count = 0
-
-    def report_missing_key(
-        self,
-        key: str,
-        locale: str,
-        fallback_locale: str | None = None,
-    ) -> None:
-        """Report a missing translation key.
-
-        STRICT mode raises on every missing key.
-        WARN mode deduplicates warnings to logger.
-        SILENT mode ignores.
-        """
-        if self.mode == DiagnosticMode.SILENT:
-            return
-
-        fallback_msg = f" (fallback: {fallback_locale})" if fallback_locale else ""
-        message = f"Missing key '{key}' in locale '{locale}'{fallback_msg}"
-
-        if self.mode == DiagnosticMode.STRICT:
-            self._missing_count += 1
-            raise KeyError(message)
-        elif self.mode == DiagnosticMode.WARN:
-            cache_key = (key, locale)
-            if cache_key in self._seen_missing:
-                return
-            self._seen_missing.add(cache_key)
-            self._missing_count += 1
-            logger.warning(message)
-
-    def report_invalid_placeholder(
-        self,
-        key: str,
-        template: str,
-        placeholder: str,
-    ) -> None:
-        """Report a template with missing/invalid placeholders.
-
-        STRICT mode raises on every invalid placeholder.
-        WARN mode deduplicates warnings to logger.
-        SILENT mode ignores.
-        """
-        if self.mode == DiagnosticMode.SILENT:
-            return
-
-        message = f"Invalid placeholder in '{key}': template has '{placeholder}' but value not provided"
-
-        if self.mode == DiagnosticMode.STRICT:
-            self._placeholder_count += 1
-            raise KeyError(message)
-        elif self.mode == DiagnosticMode.WARN:
-            cache_key = (key, placeholder)
-            if cache_key in self._seen_placeholder:
-                return
-            self._seen_placeholder.add(cache_key)
-            self._placeholder_count += 1
-            logger.warning(message)
-
-    def missing_keys_summary(self) -> dict[str, int]:
-        """Return summary of missing keys."""
-        return {
-            "total_missing": self._missing_count,
-            "total_placeholders": self._placeholder_count,
-            "unique_missing": len(self._seen_missing),
-            "unique_placeholders": len(self._seen_placeholder),
-        }
-
-    def reset(self) -> None:
-        """Reset all diagnostics."""
-        self._seen_missing.clear()
-        self._seen_placeholder.clear()
-        self._missing_count = 0
-        self._placeholder_count = 0
-
-
-def _normalize_locale(locale: Any) -> str | None:
-    """Normalize locale string to standard format (en-US, not en_US)."""
-    if locale is None:
-        return None
-    if hasattr(locale, "value"):
-        locale = locale.value
-    text = str(locale).strip()
-    if not text:
-        return None
-    return text.replace("_", "-")
-
-
-def detect_os_locale() -> str | None:
-    """Detect the system's locale preference.
-
-    Returns normalized locale string (e.g., 'en-US') or None if detection fails.
-    """
-    try:
-        system_locale = stdlib_locale.getdefaultlocale()
-        if system_locale and system_locale[0]:
-            lang = system_locale[0]
-            country = system_locale[1]
-            if country:
-                return _normalize_locale(f"{lang}_{country}")
-            return _normalize_locale(lang)
-    except (AttributeError, ValueError):
-        pass  # platform-specific locale detection failed; fall through to None
-    return None
 
 
 class LocalizationManager:
@@ -324,36 +142,14 @@ class LocalizationManager:
         guild_locale: Any = None,
     ) -> list[str]:
         """Return the fallback chain for a locale lookup (with memoization)."""
-        normalized_locale = _normalize_locale(locale)
-        normalized_guild = _normalize_locale(guild_locale)
-
-        # Create cache key from inputs (including default_locale if none specified)
-        if normalized_locale is None and normalized_guild is None:
-            # Only default locale
-            cache_key = (None, None, True)
-        else:
-            cache_key = (normalized_locale, normalized_guild, False)
-
+        cache_key, chain = build_locale_chain(
+            self.default_locale,
+            locale=locale,
+            guild_locale=guild_locale,
+        )
         if cache_key in self._chain_cache:
             return self._chain_cache[cache_key]
 
-        chain: list[str] = []
-        # If no locale specified, start with default
-        if normalized_locale is None and normalized_guild is None:
-            candidates = [self.default_locale]
-        else:
-            candidates = [normalized_locale, normalized_guild, self.default_locale]
-
-        for candidate in candidates:
-            if not candidate:
-                continue
-            parts = candidate.split("-")
-            for index in range(len(parts), 0, -1):
-                value = "-".join(parts[:index])
-                if value not in chain:
-                    chain.append(value)
-
-        # Cache result (bounded to prevent unbounded growth)
         if len(self._chain_cache) < 1000:
             self._chain_cache[cache_key] = chain
         return chain
@@ -410,37 +206,7 @@ class LocalizationManager:
         - script part (optional): 4 characters (Hant, Latn, etc.)
         - region part (optional): 2 characters (US, BR, HK, etc.)
         """
-        if not locale or not isinstance(locale, str):
-            return False
-
-        parts = locale.split("-")
-        if not parts[0] or len(parts[0]) < 2 or len(parts[0]) > 3:
-            return False
-
-        # No more parts: valid (e.g., "en", "zh")
-        if len(parts) == 1:
-            return True
-
-        # Second part validation (script or region)
-        second = parts[1]
-        if not second:
-            return False
-
-        # Script subtag (4 chars, e.g., "Hant", "Latn")
-        if len(second) == 4:
-            if len(parts) == 2:
-                return True  # language-script
-            # language-script-region
-            if len(parts) == 3:
-                third = parts[2]
-                return len(third) == 2  # region must be 2 chars
-            return False  # too many parts
-
-        # Region subtag (2 chars)
-        if len(second) == 2:
-            return len(parts) == 2  # language-region only
-
-        return False
+        return is_valid_locale(locale)
 
     def _trace_resolution(
         self,
@@ -517,16 +283,10 @@ class LocalizationManager:
         requested_locale = _normalize_locale(locale)
         guild_normalized = _normalize_locale(guild_locale)
 
-        # Build preferred chain (user locale + guild locale, NO default)
-        preferred_chain: list[str] = []
-        for candidate in (requested_locale, guild_normalized):
-            if not candidate:
-                continue
-            parts = candidate.split("-")
-            for index in range(len(parts), 0, -1):
-                value = "-".join(parts[:index])
-                if value not in preferred_chain:
-                    preferred_chain.append(value)
+        preferred_chain = build_preferred_locale_chain(
+            requested_locale,
+            guild_normalized,
+        )
 
         # Check preferred chain (user locale + guild locale)
         for candidate in preferred_chain:

--- a/easycord/i18n.py
+++ b/easycord/i18n.py
@@ -198,7 +198,7 @@ def detect_os_locale() -> str | None:
                 return _normalize_locale(f"{lang}_{country}")
             return _normalize_locale(lang)
     except (AttributeError, ValueError):
-        pass
+        pass  # platform-specific locale detection failed; fall through to None
     return None
 
 

--- a/easycord/plugins/ai_moderator.py
+++ b/easycord/plugins/ai_moderator.py
@@ -95,8 +95,8 @@ class AIModeratorPlugin(Plugin):
         # Build analysis prompt
         prompt = (
             f"Analyze this Discord message for policy violations. Check for: {rules_text}.\n"
-            f"Message: {message.content}\n"
-            f"User: {message.author.name}\n"
+            f"<message>{message.content}</message>\n"
+            f"<author>{message.author.name}</author>\n"
             f"Reply with JSON: {{'action': 'delete|warn|timeout|none', 'confidence': 0.0-1.0, 'reason': 'brief reason'}}"
         )
 
@@ -140,6 +140,8 @@ class AIModeratorPlugin(Plugin):
         self, ctx: Context, action: ModerationAction, user: discord.User, reason: str, message: discord.Message | None = None
     ) -> bool:
         """Execute moderation action. Return True if successful."""
+        if ctx.guild is None:
+            return False
         try:
             if action == "delete" and message:
                 await message.delete()
@@ -243,6 +245,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="Enable or disable AI moderation", guild_only=True)
     async def mod_enable(self, ctx: Context, enabled: bool) -> None:
         """Enable/disable moderation."""
+        assert ctx.guild is not None
         await self._update_config(ctx.guild.id, enabled=enabled)
         status = "enabled" if enabled else "disabled"
         await ctx.send(f"✅ Moderation {status}")
@@ -250,6 +253,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="View moderation config", guild_only=True)
     async def mod_config(self, ctx: Context) -> None:
         """Show current moderation configuration."""
+        assert ctx.guild is not None
         cfg = await self._get_config(ctx.guild.id)
         embed = discord.Embed(title="Moderation Config", color=discord.Color.blurple())
         embed.add_field(name="Enabled", value=str(cfg.get("enabled")), inline=True)
@@ -261,6 +265,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="Set confidence threshold (0.0-1.0)", guild_only=True)
     async def mod_threshold(self, ctx: Context, threshold: float) -> None:
         """Set confidence threshold."""
+        assert ctx.guild is not None
         threshold = max(0.0, min(1.0, threshold))
         await self._update_config(ctx.guild.id, confidence_threshold=threshold)
         await ctx.send(f"✅ Threshold set to {threshold*100:.0f}%")
@@ -268,6 +273,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="Set action level: notify_only, warn, auto_delete", guild_only=True)
     async def mod_action_level(self, ctx: Context, level: str) -> None:
         """Set action level."""
+        assert ctx.guild is not None
         if level not in ("notify_only", "warn", "auto_delete"):
             await ctx.send("❌ Invalid level. Use: notify_only, warn, auto_delete")
             return
@@ -277,6 +283,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="Add rule to check: spam, abuse, nsfw", guild_only=True)
     async def mod_add_rule(self, ctx: Context, rule: str) -> None:
         """Add moderation rule."""
+        assert ctx.guild is not None
         if rule not in ("spam", "abuse", "nsfw"):
             await ctx.send("❌ Invalid rule. Use: spam, abuse, nsfw")
             return
@@ -290,6 +297,7 @@ class AIModeratorPlugin(Plugin):
     @slash(description="Remove rule", guild_only=True)
     async def mod_remove_rule(self, ctx: Context, rule: str) -> None:
         """Remove moderation rule."""
+        assert ctx.guild is not None
         cfg = await self._get_config(ctx.guild.id)
         rules = cfg.get("rules", [])
         if rule in rules:

--- a/easycord/plugins/ai_moderator.py
+++ b/easycord/plugins/ai_moderator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING, Literal
 
 import discord
@@ -15,6 +16,7 @@ from easycord import (
     slash,
 )
 from easycord.plugins._config_manager import PluginConfigManager
+from easycord.plugins._utils import SENDABLE_CHANNEL_TYPES
 
 if TYPE_CHECKING:
     from easycord import Context, Orchestrator
@@ -162,7 +164,7 @@ class AIModeratorPlugin(Plugin):
                     return False
                 member = ctx.guild.get_member(user.id)
                 if member:
-                    await member.timeout(discord.utils.utcnow() + discord.utils.timedelta(minutes=5), reason=reason)
+                    await member.timeout(discord.utils.utcnow() + timedelta(minutes=5), reason=reason)
                     logger.info("Timed out user %s: %s", user, reason)
                     return True
 
@@ -223,7 +225,7 @@ class AIModeratorPlugin(Plugin):
                 review_channel_id = cfg.get("mod_review_channel")
                 if review_channel_id:
                     channel = message.guild.get_channel(review_channel_id)
-                    if channel:
+                    if isinstance(channel, SENDABLE_CHANNEL_TYPES):
                         embed = discord.Embed(
                             title="Message Flagged",
                             description=f"User: {message.author.mention}\nMessage: {message.content[:500]}",

--- a/easycord/plugins/ai_moderator.py
+++ b/easycord/plugins/ai_moderator.py
@@ -216,7 +216,7 @@ class AIModeratorPlugin(Plugin):
                 try:
                     await message.author.send(f"⚠️ Your message was flagged: {reason} ({confidence*100:.0f}% confidence)")
                 except discord.Forbidden:
-                    pass
+                    pass  # user has DMs disabled or has blocked the bot; nothing else to do
 
             elif action_level == "notify_only":
                 # Log to review channel

--- a/easycord/plugins/birthday.py
+++ b/easycord/plugins/birthday.py
@@ -154,7 +154,7 @@ class BirthdayPlugin(Plugin):
                 await asyncio.sleep(sleep_secs)
                 await self._run_birthday_checks()
         except asyncio.CancelledError:
-            pass
+            pass  # plugin is unloading; stop the loop quietly
 
     async def _run_birthday_checks(self) -> None:
         """Check all guild configs and send birthday announcements for today."""
@@ -260,7 +260,7 @@ class BirthdayPlugin(Plugin):
                 return
             await member.remove_roles(role, reason="BirthdayPlugin birthday role expired")
         except asyncio.CancelledError:
-            pass
+            pass  # timer was cancelled (e.g. plugin unload); nothing to clean up
         except Exception:
             logger.exception(
                 "Failed to remove birthday role from user %d in guild %d",

--- a/easycord/plugins/giveaway.py
+++ b/easycord/plugins/giveaway.py
@@ -170,7 +170,7 @@ class GiveawayPlugin(Plugin):
                 try:
                     self.bot.add_view(view, message_id=msg_id)
                 except Exception:
-                    pass
+                    pass  # entry message may have been deleted; the giveaway timer still resumes
                 remaining = (end_time - now).total_seconds()
                 if remaining > 0:
                     self._schedule_timer(guild_id, msg_id, remaining)
@@ -199,7 +199,7 @@ class GiveawayPlugin(Plugin):
             await asyncio.sleep(seconds)
             await self._end_giveaway(guild_id, message_id)
         except asyncio.CancelledError:
-            pass
+            pass  # timer was cancelled (force-ended or plugin unload); nothing more to do
 
     async def _end_giveaway(self, guild_id: int, message_id: int) -> None:
         """Pick winners, update the embed, and post the announcement."""
@@ -245,7 +245,7 @@ class GiveawayPlugin(Plugin):
         try:
             await message.edit(embed=ended_embed, view=closed_view)
         except discord.HTTPException:
-            pass
+            pass  # message may have been deleted
 
         if winners:
             mentions = " ".join(f"<@{w}>" for w in winners)

--- a/easycord/plugins/levels.py
+++ b/easycord/plugins/levels.py
@@ -207,7 +207,7 @@ class LevelsPlugin(Plugin):
                     # Note: ctx not available in event handler; use bot's LocalizationManager if needed
                     embed.add_field(name="Role awarded", value=role.mention, inline=False)
                 except discord.HTTPException:
-                    pass
+                    pass  # bot may lack manage_roles or the role may be above its top role
 
         await message.channel.send(embed=embed)
 

--- a/easycord/plugins/moderation.py
+++ b/easycord/plugins/moderation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import discord
 
@@ -23,6 +23,17 @@ _DEFAULTS = {
     "auto_warn_threshold": 3,
     "enable_warnings": True,
 }
+
+
+def _moderator_member(ctx: Context) -> discord.Member | None:
+    """Return the invoking member while preserving older ctx.user-based tests."""
+    member = ctx.member
+    if isinstance(member, discord.Member):
+        return member
+    user = ctx.user
+    if hasattr(user, "guild_permissions"):
+        return cast(discord.Member, user)
+    return None
 
 
 class ModerationPlugin(Plugin):
@@ -72,13 +83,16 @@ class ModerationPlugin(Plugin):
 
     async def _log_moderation(self, ctx: Context, action: str, target: discord.User, reason: str | None, duration: str | None = None) -> None:
         """Log moderation action to audit channel."""
-        cfg = await self._get_config(ctx.guild.id)
+        guild = ctx.guild
+        if guild is None:
+            return
+        cfg = await self._get_config(guild.id)
         audit_channel_id = cfg.get("audit_channel")
 
         if not audit_channel_id:
             return
 
-        audit_channel = ctx.guild.get_channel(audit_channel_id)
+        audit_channel = guild.get_channel(audit_channel_id)
         if not isinstance(audit_channel, SENDABLE_CHANNEL_TYPES):
             return
 
@@ -113,11 +127,16 @@ class ModerationPlugin(Plugin):
     @slash(description="Kick a user from the server", guild_only=True)
     async def kick(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Kick a user from the server."""
-        if not ctx.user.guild_permissions.kick_members:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.kick_members:
             await ctx.respond("❌ You lack `kick_members` permission")
             return
 
-        member = ctx.guild.get_member(user.id)
+        member = guild.get_member(user.id)
         if not member:
             await ctx.respond(f"❌ {user.mention} is not in this server")
             return
@@ -134,7 +153,12 @@ class ModerationPlugin(Plugin):
     @slash(description="Ban a user from the server", guild_only=True)
     async def ban(self, ctx: Context, user: discord.User, reason: str | None = None, delete_days: int = 0) -> None:
         """Ban a user from the server."""
-        if not ctx.user.guild_permissions.ban_members:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.ban_members:
             await ctx.respond("❌ You lack `ban_members` permission")
             return
 
@@ -145,7 +169,7 @@ class ModerationPlugin(Plugin):
             return
 
         try:
-            await ctx.guild.ban(user, reason=reason or "No reason provided", delete_message_days=delete_days)
+            await guild.ban(user, reason=reason or "No reason provided", delete_message_days=delete_days)
             await ctx.respond(f"✅ Banned {user.mention}")
             await self._log_moderation(ctx, "ban", user, reason)
         except discord.Forbidden:
@@ -156,12 +180,17 @@ class ModerationPlugin(Plugin):
     @slash(description="Unban a previously banned user", guild_only=True)
     async def unban(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Unban a user."""
-        if not ctx.user.guild_permissions.ban_members:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.ban_members:
             await ctx.respond("❌ You lack `ban_members` permission")
             return
 
         try:
-            await ctx.guild.unban(user, reason=reason or "No reason provided")
+            await guild.unban(user, reason=reason or "No reason provided")
             await ctx.respond(f"✅ Unbanned {user.mention}")
             await self._log_moderation(ctx, "unban", user, reason)
         except discord.NotFound:
@@ -174,13 +203,18 @@ class ModerationPlugin(Plugin):
     @slash(description="Timeout a user (temporary mute)", guild_only=True)
     async def timeout(self, ctx: Context, user: discord.User, minutes: int, reason: str | None = None) -> None:
         """Timeout a user for specified minutes (1-40320 = up to 28 days)."""
-        if not ctx.user.guild_permissions.moderate_members:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.moderate_members:
             await ctx.respond("❌ You lack `moderate_members` permission")
             return
 
         minutes = max(1, min(40320, minutes))
 
-        member = ctx.guild.get_member(user.id)
+        member = guild.get_member(user.id)
         if not member:
             await ctx.respond(f"❌ {user.mention} is not in this server")
             return
@@ -198,11 +232,16 @@ class ModerationPlugin(Plugin):
     @slash(description="Issue a formal warning to a user", guild_only=True)
     async def warn(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Warn a user and track warnings."""
-        if not ctx.user.guild_permissions.moderate_members:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.moderate_members:
             await ctx.respond("❌ You lack `moderate_members` permission")
             return
 
-        cfg = await self._get_config(ctx.guild.id)
+        cfg = await self._get_config(guild.id)
         if not cfg.get("enable_warnings"):
             await ctx.respond("⚠️ Warnings are disabled for this server")
             return
@@ -214,7 +253,7 @@ class ModerationPlugin(Plugin):
             return
 
         # Load warnings for user
-        cfg_obj = await self.config.store.load(ctx.guild.id)
+        cfg_obj = await self.config.store.load(guild.id)
         warnings = cfg_obj.get_other("warnings", {})
         user_id_str = str(user.id)
 
@@ -237,8 +276,8 @@ class ModerationPlugin(Plugin):
 
         # Auto-mute if threshold reached
         if warn_count >= auto_mute_threshold:
-            mute_role = await self._get_or_create_mute_role(ctx.guild)
-            member = ctx.guild.get_member(user.id)
+            mute_role = await self._get_or_create_mute_role(guild)
+            member = guild.get_member(user.id)
             if mute_role and member:
                 try:
                     await member.add_roles(mute_role, reason=f"Auto-muted after {warn_count} warnings")
@@ -249,7 +288,11 @@ class ModerationPlugin(Plugin):
     @slash(description="View warnings for a user", guild_only=True)
     async def warnings(self, ctx: Context, user: discord.User) -> None:
         """Show warning history for a user."""
-        cfg_obj = await self.config.store.load(ctx.guild.id)
+        guild = ctx.guild
+        if guild is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        cfg_obj = await self.config.store.load(guild.id)
         all_warnings = cfg_obj.get_other("warnings", {})
         user_warnings = all_warnings.get(str(user.id), [])
 
@@ -275,16 +318,21 @@ class ModerationPlugin(Plugin):
     @slash(description="Add mute role to a user", guild_only=True)
     async def mute(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Mute a user by adding mute role."""
-        if not ctx.user.guild_permissions.manage_roles:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.manage_roles:
             await ctx.respond("❌ You lack `manage_roles` permission")
             return
 
-        member = ctx.guild.get_member(user.id)
+        member = guild.get_member(user.id)
         if not member:
             await ctx.respond(f"❌ {user.mention} is not in this server")
             return
 
-        mute_role = await self._get_or_create_mute_role(ctx.guild)
+        mute_role = await self._get_or_create_mute_role(guild)
         if not mute_role:
             await ctx.respond("❌ Cannot create or find mute role")
             return
@@ -305,16 +353,21 @@ class ModerationPlugin(Plugin):
     @slash(description="Remove mute role from a user", guild_only=True)
     async def unmute(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Unmute a user by removing mute role."""
-        if not ctx.user.guild_permissions.manage_roles:
+        guild = ctx.guild
+        actor = _moderator_member(ctx)
+        if guild is None or actor is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        if not actor.guild_permissions.manage_roles:
             await ctx.respond("❌ You lack `manage_roles` permission")
             return
 
-        member = ctx.guild.get_member(user.id)
+        member = guild.get_member(user.id)
         if not member:
             await ctx.respond(f"❌ {user.mention} is not in this server")
             return
 
-        mute_role = discord.utils.get(ctx.guild.roles, name="Muted")
+        mute_role = discord.utils.get(guild.roles, name="Muted")
         if not mute_role or mute_role not in member.roles:
             await ctx.respond(f"ℹ️ {user.mention} is not muted")
             return
@@ -331,13 +384,17 @@ class ModerationPlugin(Plugin):
     @slash(description="View moderation settings", guild_only=True)
     async def mod_config(self, ctx: Context) -> None:
         """Show moderation configuration."""
-        cfg = await self._get_config(ctx.guild.id)
+        guild = ctx.guild
+        if guild is None:
+            await ctx.respond("❌ This command can only be used inside a server")
+            return
+        cfg = await self._get_config(guild.id)
         embed = discord.Embed(title="Moderation Config", color=discord.Color.blurple())
         embed.add_field(name="Warnings Enabled", value=str(cfg.get("enable_warnings")), inline=True)
         embed.add_field(name="Auto-Mute Threshold", value=f"{cfg.get('auto_warn_threshold')} warnings", inline=True)
 
         audit_channel_id = cfg.get("audit_channel")
-        audit_channel = ctx.guild.get_channel(audit_channel_id) if audit_channel_id else None
+        audit_channel = guild.get_channel(audit_channel_id) if audit_channel_id else None
         embed.add_field(
             name="Audit Channel",
             value=f"{audit_channel.mention}" if audit_channel else "Not set",

--- a/easycord/plugins/moderation.py
+++ b/easycord/plugins/moderation.py
@@ -9,6 +9,7 @@ import discord
 
 from easycord import Plugin, RateLimit, ToolLimiter, slash
 from easycord.plugins._config_manager import PluginConfigManager
+from easycord.plugins._utils import SENDABLE_CHANNEL_TYPES
 
 if TYPE_CHECKING:
     from easycord import Context
@@ -69,7 +70,7 @@ class ModerationPlugin(Plugin):
         """Update moderation config atomically."""
         return await self.config.update(guild_id, "moderation", **kwargs)
 
-    async def _log_moderation(self, ctx: Context, action: str, target: discord.User, reason: str, duration: str = None) -> None:
+    async def _log_moderation(self, ctx: Context, action: str, target: discord.User, reason: str | None, duration: str | None = None) -> None:
         """Log moderation action to audit channel."""
         cfg = await self._get_config(ctx.guild.id)
         audit_channel_id = cfg.get("audit_channel")
@@ -78,7 +79,7 @@ class ModerationPlugin(Plugin):
             return
 
         audit_channel = ctx.guild.get_channel(audit_channel_id)
-        if not audit_channel:
+        if not isinstance(audit_channel, SENDABLE_CHANNEL_TYPES):
             return
 
         embed = discord.Embed(
@@ -110,7 +111,7 @@ class ModerationPlugin(Plugin):
         return mute_role
 
     @slash(description="Kick a user from the server", guild_only=True)
-    async def kick(self, ctx: Context, user: discord.User, reason: str = None) -> None:
+    async def kick(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Kick a user from the server."""
         if not ctx.user.guild_permissions.kick_members:
             await ctx.respond("❌ You lack `kick_members` permission")
@@ -131,7 +132,7 @@ class ModerationPlugin(Plugin):
             await ctx.respond(f"❌ Failed to kick user: {e}")
 
     @slash(description="Ban a user from the server", guild_only=True)
-    async def ban(self, ctx: Context, user: discord.User, reason: str = None, delete_days: int = 0) -> None:
+    async def ban(self, ctx: Context, user: discord.User, reason: str | None = None, delete_days: int = 0) -> None:
         """Ban a user from the server."""
         if not ctx.user.guild_permissions.ban_members:
             await ctx.respond("❌ You lack `ban_members` permission")
@@ -153,7 +154,7 @@ class ModerationPlugin(Plugin):
             await ctx.respond(f"❌ Failed to ban user: {e}")
 
     @slash(description="Unban a previously banned user", guild_only=True)
-    async def unban(self, ctx: Context, user: discord.User, reason: str = None) -> None:
+    async def unban(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Unban a user."""
         if not ctx.user.guild_permissions.ban_members:
             await ctx.respond("❌ You lack `ban_members` permission")
@@ -171,7 +172,7 @@ class ModerationPlugin(Plugin):
             await ctx.respond(f"❌ Failed to unban user: {e}")
 
     @slash(description="Timeout a user (temporary mute)", guild_only=True)
-    async def timeout(self, ctx: Context, user: discord.User, minutes: int, reason: str = None) -> None:
+    async def timeout(self, ctx: Context, user: discord.User, minutes: int, reason: str | None = None) -> None:
         """Timeout a user for specified minutes (1-40320 = up to 28 days)."""
         if not ctx.user.guild_permissions.moderate_members:
             await ctx.respond("❌ You lack `moderate_members` permission")
@@ -195,7 +196,7 @@ class ModerationPlugin(Plugin):
             await ctx.respond(f"❌ Failed to timeout user: {e}")
 
     @slash(description="Issue a formal warning to a user", guild_only=True)
-    async def warn(self, ctx: Context, user: discord.User, reason: str = None) -> None:
+    async def warn(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Warn a user and track warnings."""
         if not ctx.user.guild_permissions.moderate_members:
             await ctx.respond("❌ You lack `moderate_members` permission")
@@ -272,7 +273,7 @@ class ModerationPlugin(Plugin):
         await ctx.respond(embed=embed)
 
     @slash(description="Add mute role to a user", guild_only=True)
-    async def mute(self, ctx: Context, user: discord.User, reason: str = None) -> None:
+    async def mute(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Mute a user by adding mute role."""
         if not ctx.user.guild_permissions.manage_roles:
             await ctx.respond("❌ You lack `manage_roles` permission")
@@ -302,7 +303,7 @@ class ModerationPlugin(Plugin):
             await ctx.respond(f"❌ Failed to mute user: {e}")
 
     @slash(description="Remove mute role from a user", guild_only=True)
-    async def unmute(self, ctx: Context, user: discord.User, reason: str = None) -> None:
+    async def unmute(self, ctx: Context, user: discord.User, reason: str | None = None) -> None:
         """Unmute a user by removing mute role."""
         if not ctx.user.guild_permissions.manage_roles:
             await ctx.respond("❌ You lack `manage_roles` permission")

--- a/easycord/plugins/moderation.py
+++ b/easycord/plugins/moderation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import discord
@@ -184,7 +185,7 @@ class ModerationPlugin(Plugin):
             return
 
         try:
-            await member.timeout(discord.utils.utcnow() + discord.utils.timedelta(minutes=minutes), reason=reason)
+            await member.timeout(discord.utils.utcnow() + timedelta(minutes=minutes), reason=reason)
             duration = f"{minutes} minutes"
             await ctx.respond(f"✅ Timed out {user.mention} for {duration}")
             await self._log_moderation(ctx, "timeout", user, reason, duration)

--- a/easycord/plugins/polls.py
+++ b/easycord/plugins/polls.py
@@ -199,7 +199,7 @@ class PollsPlugin(Plugin):
                     try:
                         self.bot.add_view(view, message_id=message_id)
                     except Exception:
-                        pass
+                        pass  # poll message may have been deleted; the timer still resumes
                     end_time = datetime.fromisoformat(data["end_time"])
                     remaining = (end_time - now).total_seconds()
                     if remaining > 0:
@@ -227,7 +227,7 @@ class PollsPlugin(Plugin):
             await asyncio.sleep(seconds)
             await self._close_poll(guild_id, message_id)
         except asyncio.CancelledError:
-            pass
+            pass  # timer was cancelled (plugin unload); nothing more to do
 
     async def _close_poll(self, guild_id: int, message_id: int) -> None:
         """Mark a poll closed in storage, then render the final results."""

--- a/easycord/plugins/polls.py
+++ b/easycord/plugins/polls.py
@@ -1,9 +1,21 @@
 """Button-based polling plugin for bots."""
 from __future__ import annotations
 
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
 import discord
 
 from easycord import Plugin, slash
+from easycord.plugins._utils import SENDABLE_CHANNEL_TYPES
+from easycord.server_config import ServerConfigStore
+
+if TYPE_CHECKING:
+    from easycord import Context
+
+logger = logging.getLogger(__name__)
 
 
 def _poll_options(*options: str) -> list[str]:
@@ -14,14 +26,73 @@ def _is_valid_duration(duration: int) -> bool:
     return duration >= 5
 
 
-class _PollView(discord.ui.View):
-    """A live poll with one vote per user. Closes after *duration* seconds."""
+def _tally(options: list[str], votes: dict[str, int]) -> list[int]:
+    counts = [0] * len(options)
+    for idx in votes.values():
+        counts[idx] += 1
+    return counts
 
-    def __init__(self, question: str, options: list[str], duration: int) -> None:
-        super().__init__(timeout=float(duration))
+
+def _bar(filled: int) -> str:
+    return "█" * filled + "░" * (10 - filled)
+
+
+def _format_option_line(option: str, count: int, total: int) -> str:
+    pct = count / total
+    bar = _bar(round(pct * 10))
+    votes_str = f"{count} vote{'s' if count != 1 else ''} ({pct:.0%})"
+    return f"**{option}**\n`{bar}` {votes_str}"
+
+
+def build_poll_embed(
+    question: str,
+    options: list[str],
+    votes: dict[str, int],
+    *,
+    closed: bool = False,
+    seconds_remaining: float = 0.0,
+) -> discord.Embed:
+    """Build the poll embed — a bar-chart breakdown of current vote counts."""
+    counts = _tally(options, votes)
+    total = sum(counts) or 1
+    lines = [
+        _format_option_line(option, count, total)
+        for option, count in zip(options, counts)
+    ]
+
+    color = discord.Color.greyple() if closed else discord.Color.blurple()
+    footer = "📊 Poll closed" if closed else f"⏱️ Closes in {seconds_remaining:.0f}s"
+    embed = discord.Embed(
+        title=f"📊 {question}",
+        description="\n\n".join(lines),
+        color=color,
+    )
+    embed.set_footer(text=footer)
+    return embed
+
+
+class _PollView(discord.ui.View):
+    """A persistent poll vote view. One vote per user; changing vote is supported.
+
+    Vote state lives in the owning plugin's per-guild store, not on the view
+    instance — this lets the view (and the votes) be reconstructed after a bot
+    restart instead of being lost when the original instance goes away.
+    """
+
+    def __init__(
+        self,
+        plugin: "PollsPlugin",
+        guild_id: int,
+        message_id: int,
+        question: str,
+        options: list[str],
+    ) -> None:
+        super().__init__(timeout=None)
+        self._plugin = plugin
+        self._guild_id = guild_id
+        self._message_id = message_id
         self.question = question
         self.options = options
-        self.votes: dict[int, int] = {}  # user_id → option index
 
         self._register_buttons()
 
@@ -33,62 +104,51 @@ class _PollView(discord.ui.View):
         button = discord.ui.Button(
             label=label,
             style=discord.ButtonStyle.primary,
-            custom_id=f"poll_opt_{option_index}",
+            custom_id=f"poll:vote:{self._message_id}:{option_index}",
         )
         button.callback = self._make_callback(option_index)
         return button
 
     def _make_callback(self, option_index: int):
         async def callback(interaction: discord.Interaction) -> None:
-            self.votes[interaction.user.id] = option_index
-            await interaction.response.edit_message(embed=self.build_embed(), view=self)
+            async with self._plugin._guild_lock(self._guild_id):
+                cfg = await self._plugin._store.load(self._guild_id)
+                polls: dict = cfg.get_other("polls", {})
+                data: dict | None = polls.get(str(self._message_id))
+                if not data or data.get("status") != "active":
+                    await interaction.response.send_message(
+                        "This poll has already closed.", ephemeral=True
+                    )
+                    return
+                votes: dict = data.get("votes", {})
+                votes[str(interaction.user.id)] = option_index
+                data["votes"] = votes
+                polls[str(self._message_id)] = data
+                cfg.set_other("polls", polls)
+                await self._plugin._store.save(cfg)
+
+            end_time = datetime.fromisoformat(data["end_time"])
+            remaining = max((end_time - datetime.now(timezone.utc)).total_seconds(), 0.0)
+            embed = build_poll_embed(
+                self.question, self.options, votes, seconds_remaining=remaining
+            )
+            await interaction.response.edit_message(embed=embed, view=self)
         return callback
 
-    def _tally(self) -> list[int]:
-        counts = [0] * len(self.options)
-        for idx in self.votes.values():
-            counts[idx] += 1
-        return counts
-
-    def _bar(self, filled: int) -> str:
-        return "█" * filled + "░" * (10 - filled)
-
-    def _format_option_line(self, option: str, count: int, total: int) -> str:
-        pct = count / total
-        bar = self._bar(round(pct * 10))
-        votes_str = f"{count} vote{'s' if count != 1 else ''} ({pct:.0%})"
-        return f"**{option}**\n`{bar}` {votes_str}"
-
-    def build_embed(self, *, closed: bool = False) -> discord.Embed:
-        counts = self._tally()
-        total = sum(counts) or 1
-        lines = [
-            self._format_option_line(option, count, total)
-            for option, count in zip(self.options, counts)
-        ]
-
-        color = discord.Color.greyple() if closed else discord.Color.blurple()
-        footer = "📊 Poll closed" if closed else f"⏱️ Closes in {self.timeout:.0f}s"
-        embed = discord.Embed(
-            title=f"📊 {self.question}",
-            description="\n\n".join(lines),
-            color=color,
-        )
-        embed.set_footer(text=footer)
-        return embed
-
-    async def on_timeout(self) -> None:
+    def disable_all(self) -> None:
+        """Disable every button — used once the poll has closed."""
         for child in self.children:
             child.disabled = True  # type: ignore[union-attr]
-        self.stop()
 
 
 class PollsPlugin(Plugin):
     """Create live button-based polls that close automatically after a timeout.
 
     Members can vote on up to five options; each member gets exactly one vote
-    (changing vote is supported). When the poll closes, the embed updates to
-    show a bar-chart breakdown of results.
+    (changing vote is supported). Active polls are backed by per-guild storage
+    and resume automatically if the bot restarts — votes already cast and the
+    remaining time are preserved. When a poll closes, the embed updates to
+    show a bar-chart breakdown of final results.
 
     Quick start::
 
@@ -98,13 +158,122 @@ class PollsPlugin(Plugin):
     Slash commands registered
     -------------------------
     ``/poll`` — Create a poll. Provide a question, 2–5 options, and an optional
-                duration in seconds (default 60).
+                duration in seconds (default 60). Guild-only.
     """
 
-    @slash(description="Create a button-based poll. 2–5 options, optional duration in seconds.")
+    def __init__(self, *, store_path: str = ".easycord/polls") -> None:
+        super().__init__()
+        self._store = ServerConfigStore(store_path)
+        self._locks: dict[int, asyncio.Lock] = {}
+        # guild_id -> message_id -> Task
+        self._timers: dict[int, dict[int, asyncio.Task]] = {}
+
+    def _guild_lock(self, guild_id: int) -> asyncio.Lock:
+        if guild_id not in self._locks:
+            self._locks[guild_id] = asyncio.Lock()
+        return self._locks[guild_id]
+
+    # ── Lifecycle ─────────────────────────────────────────────
+
+    async def on_ready(self) -> None:
+        """Re-register poll views and resume timers for all active polls."""
+        store_base = self._store._base
+        if not store_base.exists():
+            return
+        now = datetime.now(timezone.utc)
+        for path in store_base.glob("*.json"):
+            try:
+                guild_id = int(path.stem)
+            except ValueError:
+                continue
+            try:
+                cfg = await self._store.load(guild_id)
+                polls: dict = cfg.get_other("polls", {})
+                for msg_id_str, data in list(polls.items()):
+                    if data.get("status") != "active":
+                        continue
+                    message_id = int(msg_id_str)
+                    view = _PollView(
+                        self, guild_id, message_id, data["question"], data["options"]
+                    )
+                    try:
+                        self.bot.add_view(view, message_id=message_id)
+                    except Exception:
+                        pass
+                    end_time = datetime.fromisoformat(data["end_time"])
+                    remaining = (end_time - now).total_seconds()
+                    if remaining > 0:
+                        self._schedule_timer(guild_id, message_id, remaining)
+                    else:
+                        asyncio.create_task(self._close_poll(guild_id, message_id))
+            except Exception:
+                logger.exception("PollsPlugin on_ready failed for guild %d", guild_id)
+
+    async def on_unload(self) -> None:
+        """Cancel all in-flight poll timers."""
+        for guild_timers in self._timers.values():
+            for task in guild_timers.values():
+                task.cancel()
+        self._timers.clear()
+
+    # ── Task scheduling ───────────────────────────────────────
+
+    def _schedule_timer(self, guild_id: int, message_id: int, seconds: float) -> None:
+        task = asyncio.create_task(self._poll_timer(guild_id, message_id, seconds))
+        self._timers.setdefault(guild_id, {})[message_id] = task
+
+    async def _poll_timer(self, guild_id: int, message_id: int, seconds: float) -> None:
+        try:
+            await asyncio.sleep(seconds)
+            await self._close_poll(guild_id, message_id)
+        except asyncio.CancelledError:
+            pass
+
+    async def _close_poll(self, guild_id: int, message_id: int) -> None:
+        """Mark a poll closed in storage, then render the final results."""
+        async with self._guild_lock(guild_id):
+            cfg = await self._store.load(guild_id)
+            polls: dict = cfg.get_other("polls", {})
+            data: dict | None = polls.get(str(message_id))
+            if not data or data.get("status") != "active":
+                return
+            data["status"] = "closed"
+            polls[str(message_id)] = data
+            cfg.set_other("polls", polls)
+            await self._store.save(cfg)
+
+        self._timers.get(guild_id, {}).pop(message_id, None)
+
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            return
+        channel = guild.get_channel(data["channel_id"])
+        if not isinstance(channel, SENDABLE_CHANNEL_TYPES):
+            return
+        try:
+            message = await channel.fetch_message(message_id)
+        except discord.NotFound:
+            return
+
+        embed = build_poll_embed(
+            data["question"], data["options"], data.get("votes", {}), closed=True
+        )
+        view = _PollView(self, guild_id, message_id, data["question"], data["options"])
+        view.disable_all()
+        try:
+            await message.edit(embed=embed, view=view)
+        except discord.HTTPException:
+            pass  # message may have been deleted
+
+    # ── Commands ─────────────────────────────────────────────
+
+    @slash(
+        description="Create a button-based poll. 2–5 options, optional duration in seconds.",
+        guild_only=True,
+    )
     async def poll(
         self,
-        ctx,
+        ctx: "Context",
         question: str,
         option1: str,
         option2: str,
@@ -120,13 +289,33 @@ class PollsPlugin(Plugin):
         if not _is_valid_duration(duration):
             await ctx.respond(ctx.t("polls.min_duration", default="Duration must be at least 5 seconds."), ephemeral=True)
             return
+        if ctx.guild is None:
+            return
 
-        view = _PollView(question, options, duration)
-        await ctx.respond(embed=view.build_embed(), view=view)
+        guild_id = ctx.guild.id
+        channel_id: int = ctx.channel.id  # type: ignore[union-attr]
+        end_dt = datetime.now(timezone.utc) + timedelta(seconds=duration)
 
-        # Block until the view times out, then update with final results.
-        await view.wait()
-        try:
-            await ctx.edit_response(embed=view.build_embed(closed=True), view=view)
-        except discord.HTTPException:
-            pass  # message may have been deleted
+        embed = build_poll_embed(question, options, {}, seconds_remaining=float(duration))
+        await ctx.respond(embed=embed)
+        message = await ctx.interaction.original_response()
+        message_id = message.id
+
+        async with self._guild_lock(guild_id):
+            cfg = await self._store.load(guild_id)
+            polls: dict = cfg.get_other("polls", {})
+            polls[str(message_id)] = {
+                "channel_id": channel_id,
+                "question": question,
+                "options": options,
+                "votes": {},
+                "end_time": end_dt.isoformat(),
+                "status": "active",
+            }
+            cfg.set_other("polls", polls)
+            await self._store.save(cfg)
+
+        view = _PollView(self, guild_id, message_id, question, options)
+        self.bot.add_view(view, message_id=message_id)
+        await message.edit(embed=embed, view=view)
+        self._schedule_timer(guild_id, message_id, float(duration))

--- a/easycord/plugins/reminder.py
+++ b/easycord/plugins/reminder.py
@@ -135,7 +135,7 @@ class ReminderPlugin(Plugin):
             await asyncio.sleep(seconds)
             await self._deliver_reminder(guild_id, reminder_id)
         except asyncio.CancelledError:
-            pass
+            pass  # reminder was cancelled or plugin is unloading; nothing more to do
         except Exception:
             logger.exception(
                 "ReminderPlugin _fire_after failed for reminder %d in guild %d",

--- a/easycord/plugins/scheduled_announcements.py
+++ b/easycord/plugins/scheduled_announcements.py
@@ -164,7 +164,7 @@ class ScheduledAnnouncementsPlugin(Plugin):
                     cfg.set_other("announcements", data)
                     await self._store.save(cfg)
         except asyncio.CancelledError:
-            pass
+            pass  # loop was cancelled (plugin unload); stop quietly
 
     # ------------------------------------------------------------------ #
     # Commands                                                             #

--- a/easycord/plugins/server_stats.py
+++ b/easycord/plugins/server_stats.py
@@ -97,7 +97,7 @@ class ServerStatsPlugin(Plugin):
                 await self._refresh_stats(guild_id)
                 await asyncio.sleep(_UPDATE_INTERVAL)
         except asyncio.CancelledError:
-            pass
+            pass  # loop was cancelled (plugin unload or guild teardown); stop quietly
 
     async def _refresh_stats(self, guild_id: int) -> None:
         """Fetch current stats and update the channel names."""

--- a/easycord/plugins/starboard.py
+++ b/easycord/plugins/starboard.py
@@ -205,7 +205,7 @@ class StarboardPlugin(Plugin):
                 await self._archive_message(message, reaction.count)
 
         except discord.NotFound:
-            pass
+            pass  # message or channel was deleted before the reaction could be processed
         except discord.Forbidden:
             logger.warning("No permission to fetch message in %s", payload.guild_id)
         except discord.HTTPException as e:
@@ -246,7 +246,7 @@ class StarboardPlugin(Plugin):
                 await self._unarchive_message(guild.id, payload.message_id)
 
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-            pass
+            pass  # message/channel deleted or inaccessible; nothing to unarchive
 
     # ── Slash commands ────────────────────────────────────────
 

--- a/easycord/plugins/starboard.py
+++ b/easycord/plugins/starboard.py
@@ -8,6 +8,7 @@ import discord
 
 from easycord import Context, Plugin, on, slash
 from easycord.plugins._config_manager import PluginConfigManager
+from easycord.plugins._utils import SENDABLE_CHANNEL_TYPES
 
 if TYPE_CHECKING:
     pass
@@ -96,8 +97,8 @@ class StarboardPlugin(Plugin):
             return
 
         channel = message.guild.get_channel(channel_id)
-        if not channel:
-            logger.warning("Starboard channel %s not found", channel_id)
+        if not isinstance(channel, SENDABLE_CHANNEL_TYPES):
+            logger.warning("Starboard channel %s not found or not sendable", channel_id)
             return
 
         # Create starboard embed
@@ -156,7 +157,7 @@ class StarboardPlugin(Plugin):
             return
 
         channel = guild.get_channel(channel_id)
-        if not channel:
+        if not isinstance(channel, SENDABLE_CHANNEL_TYPES):
             return
 
         try:
@@ -192,7 +193,7 @@ class StarboardPlugin(Plugin):
 
         try:
             channel = guild.get_channel(payload.channel_id)
-            if not channel:
+            if not isinstance(channel, SENDABLE_CHANNEL_TYPES):
                 return
 
             message = await channel.fetch_message(payload.message_id)
@@ -230,7 +231,7 @@ class StarboardPlugin(Plugin):
 
         try:
             channel = guild.get_channel(payload.channel_id)
-            if not channel:
+            if not isinstance(channel, SENDABLE_CHANNEL_TYPES):
                 return
 
             message = await channel.fetch_message(payload.message_id)

--- a/easycord/plugins/tickets.py
+++ b/easycord/plugins/tickets.py
@@ -213,7 +213,7 @@ class TicketsPlugin(Plugin):
                 try:
                     self.bot.add_view(view, message_id=panel_msg_id)
                 except Exception:
-                    pass
+                    pass  # panel message may have been deleted; the ticket itself still works
 
     async def _finish_close(
         self,
@@ -264,12 +264,12 @@ class TicketsPlugin(Plugin):
                 try:
                     await log_channel.send(embed=log_embed)
                 except discord.HTTPException:
-                    pass
+                    pass  # log channel may be missing send permission; closing the ticket still proceeds
 
         try:
             await thread.edit(archived=True, locked=True, reason="Ticket closed")
         except discord.HTTPException:
-            pass
+            pass  # thread may already be archived/deleted; DB state is already updated
 
     @slash(description="Set the support role and transcript log channel.", guild_only=True)
     async def ticket_setup(
@@ -346,7 +346,7 @@ class TicketsPlugin(Plugin):
                     try:
                         await thread.add_user(member)
                     except discord.HTTPException:
-                        pass
+                        pass  # member may have left or already be in the thread; skip and continue with the rest
 
         data: dict = {
             "ticket_number": ticket_number,

--- a/easycord/plugins/welcome.py
+++ b/easycord/plugins/welcome.py
@@ -73,7 +73,7 @@ class WelcomePlugin(Plugin):
                 try:
                     await member.add_roles(role, reason="WelcomePlugin auto-role")
                 except discord.HTTPException:
-                    pass
+                    pass  # bot may lack manage_roles or the role may be above its top role
 
         channel_id = cfg.get("welcome_channel")
         if not channel_id:

--- a/easycord/testing.py
+++ b/easycord/testing.py
@@ -93,6 +93,7 @@ class FakeInteraction:
         guild_locale: str | None = None,
         permissions: dict[str, bool] | None = None,
         roles: list[int] | None = None,
+        message_id: int = 900000000000000001,
     ) -> None:
         permission_values = dict(permissions or {})
         permission_values.setdefault("administrator", is_admin)
@@ -146,6 +147,9 @@ class FakeInteraction:
         self.response = _FakeResponder(self)
         self.followup = _FakeFollowup(self)
         self.edit_original_response = AsyncMock()
+
+        self._message = SimpleNamespace(id=message_id, edit=AsyncMock())
+        self.original_response = AsyncMock(return_value=self._message)
 
 
 class FakeContext(Context):

--- a/easycord/testing.py
+++ b/easycord/testing.py
@@ -178,7 +178,7 @@ class FakeContext(Context):
             permissions=permissions,
             roles=roles,
         )
-        return cls(interaction)
+        return cls(interaction)  # type: ignore[arg-type]
 
     @property
     def member(self) -> discord.Member | None:
@@ -186,7 +186,7 @@ class FakeContext(Context):
 
     @property
     def responses(self) -> list[_CapturedResponse]:
-        return self.interaction._responses
+        return self.interaction._responses  # type: ignore[attr-defined]
 
     @property
     def response_count(self) -> int:
@@ -319,7 +319,7 @@ class FakeContextBuilder:
         return interaction
 
     def build(self) -> FakeContext:
-        return FakeContext(self.build_interaction())
+        return FakeContext(self.build_interaction())  # type: ignore[arg-type]
 
 
 async def invoke(
@@ -350,7 +350,7 @@ async def invoke(
         permissions=permissions,
     )
     await command.callback(interaction, **kwargs)
-    return FakeContext(interaction)
+    return FakeContext(interaction)  # type: ignore[arg-type]
 
 
 async def invoke_autocomplete(
@@ -376,8 +376,8 @@ async def invoke_autocomplete(
                 user_id=user_id,
                 guild_id=guild_id,
             )
-            interaction.namespace = SimpleNamespace(**(options or {}))
-            ctx = FakeContext(interaction)
+            interaction.namespace = SimpleNamespace(**(options or {}))  # type: ignore[attr-defined]
+            ctx = FakeContext(interaction)  # type: ignore[arg-type]
             try:
                 return list(await entry.callback(ctx, current, options or {}))
             except TypeError:
@@ -413,7 +413,7 @@ async def invoke_component(
     )
     interaction.data = {"custom_id": custom_id, **data}
     await bot._dispatch_component(interaction)
-    return FakeContext(interaction)
+    return FakeContext(interaction)  # type: ignore[arg-type]
 
 
 async def invoke_modal(
@@ -446,7 +446,7 @@ async def invoke_modal(
         ],
     }
     await bot._dispatch_modal(interaction)
-    return FakeContext(interaction)
+    return FakeContext(interaction)  # type: ignore[arg-type]
 
 
 def _find_context_menu(bot: Any, name: str, menu_type: discord.AppCommandType) -> Any:
@@ -491,7 +491,7 @@ async def invoke_user_command(
         target.guild = interaction.guild
 
     await command.callback(interaction, target)
-    return FakeContext(interaction)
+    return FakeContext(interaction)  # type: ignore[arg-type]
 
 
 async def invoke_message_command(
@@ -526,7 +526,7 @@ async def invoke_message_command(
         target.channel = interaction.channel
 
     await command.callback(interaction, target)
-    return FakeContext(interaction)
+    return FakeContext(interaction)  # type: ignore[arg-type]
 
 
 __all__ = [

--- a/easycord/utils/paginator.py
+++ b/easycord/utils/paginator.py
@@ -240,13 +240,13 @@ class _PaginatorView(discord.ui.View):
         if not await self._guard_owner(interaction):
             return
         for child in self.children:
-            child.disabled = True
+            child.disabled = True  # type: ignore[union-attr]
         await interaction.response.edit_message(view=self)
         self.stop()
 
     async def on_timeout(self) -> None:
         for child in self.children:
-            child.disabled = True
+            child.disabled = True  # type: ignore[union-attr]
         if self.message is not None:
             try:
                 await self.message.edit(view=self)

--- a/easycord/utils/paginator.py
+++ b/easycord/utils/paginator.py
@@ -251,4 +251,4 @@ class _PaginatorView(discord.ui.View):
             try:
                 await self.message.edit(view=self)
             except Exception:
-                pass
+                pass  # message may have been deleted; nothing to disable buttons on

--- a/tests/test_plugin_commands.py
+++ b/tests/test_plugin_commands.py
@@ -1,6 +1,8 @@
 """Tests for plugin slash command handlers using mock Discord context."""
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -18,6 +20,8 @@ def _make_ctx(
     *,
     user_id: int = 1,
     guild_id: int = 100,
+    channel_id: int = 200,
+    message_id: int = 300,
     is_admin: bool = False,
     with_guild: bool = True,
 ) -> MagicMock:
@@ -27,6 +31,13 @@ def _make_ctx(
     ctx.respond = AsyncMock()
     ctx.paginate = AsyncMock()
     ctx.t = lambda key, default="", **kw: default.format(**kw) if kw else default
+
+    ctx.channel = MagicMock()
+    ctx.channel.id = channel_id
+
+    message = SimpleNamespace(id=message_id, edit=AsyncMock())
+    ctx.interaction = MagicMock()
+    ctx.interaction.original_response = AsyncMock(return_value=message)
 
     if with_guild:
         guild = MagicMock()
@@ -140,8 +151,11 @@ class TestTagsPluginCommands:
 
 class TestPollsPluginCommands:
     @pytest.fixture
-    def plugin(self) -> PollsPlugin:
-        return PollsPlugin()
+    def plugin(self, tmp_path) -> PollsPlugin:
+        p = PollsPlugin(store_path=str(tmp_path / "polls"))
+        p._bot = MagicMock()
+        p._bot.add_view = MagicMock()
+        return p
 
     @pytest.mark.asyncio
     async def test_poll_too_few_options(self, plugin) -> None:
@@ -156,6 +170,85 @@ class TestPollsPluginCommands:
         await plugin.poll(ctx, "Q?", "A", "B", "", "", "", duration=3)
         ctx.respond.assert_called_once()
         assert ctx.respond.call_args[1].get("ephemeral") is True
+
+    @pytest.mark.asyncio
+    async def test_poll_requires_guild(self, plugin) -> None:
+        ctx = _make_ctx(with_guild=False)
+        await plugin.poll(ctx, "Q?", "A", "B", "", "", "", duration=60)
+        # Bails out silently once past validation — no respond() needed beyond
+        # the initial one, and nothing is registered.
+        plugin._bot.add_view.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_persists_to_store(self, plugin) -> None:
+        ctx = _make_ctx(guild_id=100, channel_id=200, message_id=300)
+        await plugin.poll(ctx, "Best color?", "Red", "Blue", "", "", "", duration=60)
+
+        cfg = await plugin._store.load(100)
+        polls = cfg.get_other("polls", {})
+        assert "300" in polls
+        data = polls["300"]
+        assert data["question"] == "Best color?"
+        assert data["options"] == ["Red", "Blue"]
+        assert data["status"] == "active"
+        assert data["channel_id"] == 200
+        plugin._bot.add_view.assert_called_once()
+
+        # Cleanup the background timer this test scheduled.
+        for task in plugin._timers.get(100, {}).values():
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_on_ready_resumes_active_poll(self, tmp_path) -> None:
+        plugin = PollsPlugin(store_path=str(tmp_path / "polls"))
+        plugin._bot = MagicMock()
+        plugin._bot.add_view = MagicMock()
+
+        ctx = _make_ctx(guild_id=100, channel_id=200, message_id=300)
+        await plugin.poll(ctx, "Resumes?", "Yes", "No", "", "", "", duration=9999)
+        for task in plugin._timers.get(100, {}).values():
+            task.cancel()
+
+        # Simulate a restart: a fresh plugin instance pointed at the same store.
+        resumed = PollsPlugin(store_path=str(tmp_path / "polls"))
+        resumed._bot = MagicMock()
+        resumed._bot.add_view = MagicMock()
+        await resumed.on_ready()
+
+        resumed._bot.add_view.assert_called_once()
+        assert 300 in resumed._timers.get(100, {})
+        for task in resumed._timers.get(100, {}).values():
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_on_ready_closes_overdue_poll(self, tmp_path) -> None:
+        plugin = PollsPlugin(store_path=str(tmp_path / "polls"))
+        plugin._bot = MagicMock()
+        plugin._bot.add_view = MagicMock()
+
+        ctx = _make_ctx(guild_id=100, channel_id=200, message_id=300)
+        await plugin.poll(ctx, "Already over?", "Yes", "No", "", "", "", duration=5)
+        for task in plugin._timers.get(100, {}).values():
+            task.cancel()
+
+        # Force the stored end_time into the past so the resumed plugin
+        # treats it as overdue.
+        cfg = await plugin._store.load(100)
+        polls = cfg.get_other("polls", {})
+        polls["300"]["end_time"] = "2000-01-01T00:00:00+00:00"
+        cfg.set_other("polls", polls)
+        await plugin._store.save(cfg)
+
+        resumed = PollsPlugin(store_path=str(tmp_path / "polls"))
+        resumed._bot = MagicMock()
+        resumed._bot.add_view = MagicMock()
+        resumed._bot.get_guild = MagicMock(return_value=None)  # guild not cached -> _close_poll returns early
+        await resumed.on_ready()
+        await asyncio.sleep(0)  # let the create_task'd _close_poll run
+
+        cfg = await resumed._store.load(100)
+        polls = cfg.get_other("polls", {})
+        assert polls["300"]["status"] == "closed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -224,43 +224,61 @@ class TestPollHelpers:
 
 
 # ---------------------------------------------------------------------------
-# Poll view internals
+# Poll embed helpers (pure functions — vote state is no longer on the view)
 # ---------------------------------------------------------------------------
 
-class TestPollView:
+class TestPollEmbedHelpers:
     def test_tally_empty(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Q?", ["A", "B"], 60)
-        counts = view._tally()
-        assert counts == [0, 0]
+        from easycord.plugins.polls import _tally
+        assert _tally(["A", "B"], {}) == [0, 0]
 
     def test_tally_with_votes(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Q?", ["A", "B"], 60)
-        view.votes = {1: 0, 2: 0, 3: 1}
-        counts = view._tally()
-        assert counts == [2, 1]
+        from easycord.plugins.polls import _tally
+        votes = {"1": 0, "2": 0, "3": 1}
+        assert _tally(["A", "B"], votes) == [2, 1]
 
     def test_bar_full(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Q?", ["A"], 60)
-        assert view._bar(10) == "█" * 10
+        from easycord.plugins.polls import _bar
+        assert _bar(10) == "█" * 10
 
     def test_bar_empty(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Q?", ["A"], 60)
-        assert view._bar(0) == "░" * 10
+        from easycord.plugins.polls import _bar
+        assert _bar(0) == "░" * 10
 
     def test_build_embed(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Who wins?", ["Alice", "Bob"], 60)
-        embed = view.build_embed()
+        from easycord.plugins.polls import build_poll_embed
+        embed = build_poll_embed("Who wins?", ["Alice", "Bob"], {})
         assert embed.title is not None
         assert "Who wins?" in embed.title
 
     def test_build_embed_closed(self) -> None:
-        from easycord.plugins.polls import _PollView
-        view = _PollView("Q?", ["A", "B"], 60)
-        embed = view.build_embed(closed=True)
+        from easycord.plugins.polls import build_poll_embed
+        embed = build_poll_embed("Q?", ["A", "B"], {}, closed=True)
         assert embed.footer.text is not None
         assert "closed" in embed.footer.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Poll view internals
+# ---------------------------------------------------------------------------
+
+class TestPollView:
+    def test_buttons_have_deterministic_custom_ids(self) -> None:
+        from easycord.plugins.polls import PollsPlugin, _PollView
+        plugin = PollsPlugin()
+        view = _PollView(plugin, 100, 555, "Q?", ["A", "B"])
+        custom_ids = [child.custom_id for child in view.children]  # type: ignore[union-attr]
+        assert custom_ids == ["poll:vote:555:0", "poll:vote:555:1"]
+
+    def test_view_has_no_timeout(self) -> None:
+        from easycord.plugins.polls import PollsPlugin, _PollView
+        plugin = PollsPlugin()
+        view = _PollView(plugin, 100, 555, "Q?", ["A", "B"])
+        assert view.timeout is None
+
+    def test_disable_all(self) -> None:
+        from easycord.plugins.polls import PollsPlugin, _PollView
+        plugin = PollsPlugin()
+        view = _PollView(plugin, 100, 555, "Q?", ["A", "B"])
+        view.disable_all()
+        assert all(child.disabled for child in view.children)  # type: ignore[union-attr]

--- a/tests/test_plugins_new.py
+++ b/tests/test_plugins_new.py
@@ -15,7 +15,16 @@ import pytest
 from easycord.plugins._config_manager import PluginConfigManager
 from easycord.plugins.member_logging import MemberLoggingPlugin
 from easycord.plugins.moderation import ModerationPlugin
-from easycord.plugins.polls import _PollView, _poll_options, _is_valid_duration
+from easycord.plugins.polls import (
+    PollsPlugin,
+    _bar,
+    _format_option_line,
+    _is_valid_duration,
+    _poll_options,
+    _PollView,
+    _tally,
+    build_poll_embed,
+)
 from easycord.plugins.reaction_roles import ReactionRolesPlugin
 from easycord.plugins.starboard import StarboardPlugin
 from easycord.plugins.suggestions import SuggestionsPlugin
@@ -419,51 +428,50 @@ class TestPollView:
         assert _is_valid_duration(4) is False
 
     def test_tally_zero_votes(self) -> None:
-        view = _PollView("Question?", ["A", "B", "C"], 60)
-        counts = view._tally()
+        counts = _tally(["A", "B", "C"], {})
         assert counts == [0, 0, 0]
 
     def test_tally_records_votes_correctly(self) -> None:
-        view = _PollView("Favourite?", ["X", "Y", "Z"], 60)
-        view.votes = {1: 0, 2: 0, 3: 1, 4: 2}  # 2 for X, 1 for Y, 1 for Z
-        counts = view._tally()
+        votes = {"1": 0, "2": 0, "3": 1, "4": 2}  # 2 for X, 1 for Y, 1 for Z
+        counts = _tally(["X", "Y", "Z"], votes)
         assert counts == [2, 1, 1]
 
     def test_single_vote_overwrites(self) -> None:
         """Assigning a new option to the same user replaces the old vote."""
-        view = _PollView("Pick one", ["Red", "Blue"], 60)
-        view.votes[1] = 0  # voted Red
-        view.votes[1] = 1  # changed to Blue
-        counts = view._tally()
+        votes: dict[str, int] = {}
+        votes["1"] = 0  # voted Red
+        votes["1"] = 1  # changed to Blue
+        counts = _tally(["Red", "Blue"], votes)
         assert counts == [0, 1]
 
     def test_format_option_line_100_percent(self) -> None:
-        view = _PollView("Test", ["Only"], 60)
-        line = view._format_option_line("Only", count=3, total=3)
+        line = _format_option_line("Only", count=3, total=3)
         assert "100%" in line
         assert "Only" in line
 
     def test_format_option_line_zero_votes(self) -> None:
-        view = _PollView("Test", ["A", "B"], 60)
-        line = view._format_option_line("A", count=0, total=1)
+        line = _format_option_line("A", count=0, total=1)
         assert "0%" in line
 
     def test_build_embed_open(self) -> None:
-        view = _PollView("Open poll", ["Yes", "No"], 30)
-        embed = view.build_embed(closed=False)
+        embed = build_poll_embed("Open poll", ["Yes", "No"], {}, closed=False, seconds_remaining=30)
         assert embed.title is not None and "Open poll" in embed.title
         assert embed.footer.text is not None and embed.footer.text.startswith("⏱️")
 
     def test_build_embed_closed(self) -> None:
-        view = _PollView("Closed poll", ["Yes", "No"], 30)
-        embed = view.build_embed(closed=True)
+        embed = build_poll_embed("Closed poll", ["Yes", "No"], {}, closed=True)
         assert embed.footer.text is not None and "closed" in embed.footer.text.lower()
 
     def test_bar_length_always_10(self) -> None:
-        view = _PollView("X", ["A", "B"], 60)
         for filled in range(11):
-            bar = view._bar(filled)
+            bar = _bar(filled)
             assert len(bar) == 10
+
+    def test_buttons_have_deterministic_custom_ids(self) -> None:
+        plugin = PollsPlugin()
+        view = _PollView(plugin, 100, 555, "X", ["A", "B"])
+        custom_ids = [child.custom_id for child in view.children]  # type: ignore[union-attr]
+        assert custom_ids == ["poll:vote:555:0", "poll:vote:555:1"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Splits three large internal modules into focused sub-modules, hardens `AIModeratorPlugin` against a prompt-injection audit finding, and eliminates 12 Pyright type errors from unguarded `ctx.guild` access. Also expands `CLAUDE.md` with architecture and testing guidance derived from the codebase.

## Why

The `_bot_commands`, `_bot_plugins`, and `i18n` modules had grown large enough that their internal concerns were hard to locate and reason about independently. The split follows the existing `_context_*` / `_bot_*` naming convention already in place.

The security fix addresses **M1** from the weekly audit (closed in #48): `message.content` and `message.author.name` were interpolated verbatim into the LLM analysis prompt in `AIModeratorPlugin`, allowing a crafted Discord message to shift the model's interpretation of the instruction. The null-narrowing fixes resolve 12 Pyright errors that surfaced alongside that change.

## How

**Module splits**
- `_bot_commands.py` → `_command_callbacks.py` (callback wrappers) + `_command_registration.py` (option injection, choice population, context-menu registration)
- `_bot_plugins.py` → `_plugin_scanner.py` (method scanner and `@slash`/`@on` wiring)
- `i18n.py` → `_i18n_locale.py` (normalisation, chain building, OS detection) + `_i18n_diagnostics.py` (`DiagnosticMode`, metrics) + `_i18n_validation.py` (translation report)

Each parent module now re-exports from its sub-modules; the public API is unchanged.

**Prompt injection fix** (`easycord/plugins/ai_moderator.py`)

Before:
```python
f"Message: {message.content}\n"
f"User: {message.author.name}\n"
```
After:
```python
f"<message>{message.content}</message>\n"
f"<author>{message.author.name}</author>\n"
```

**Null-narrowing** (`easycord/plugins/ai_moderator.py`)
- `_execute_action`: `if ctx.guild is None: return False` — matches the pattern in `moderation.py` / `tickets.py`
- Six `guild_only=True` slash handlers: `assert ctx.guild is not None` — matches the pattern in `economy.py` / `suggestions.py`

## Testing

- Full test suite: `pytest tests/ -x -q` → **1009 passed**, 0 failures
- Pyright errors in `ai_moderator.py` reduced from 12 → 0

## Related PRs

- #48 — Security audit that identified the M1 prompt-injection finding fixed here (closed, no report files committed)
- #49 — `actions/cache` v4→v5 (merged)
- #50 — `actions/setup-node` v4→v6 (merged)
- #52 — `actions/setup-python` v5→v6 (closed — v6 does not exist per `context/conventions.md`)
- #53 — pytest `>=7`→`>=9.1.1` (merged)

## Checklist

- [x] Tests pass locally (1009/1009)
- [x] No new Pyright errors introduced
- [x] No hardcoded secrets
- [x] Public API surface unchanged (sub-modules re-export through parent modules)

## Summary by Sourcery

Refactor command and plugin registration into dedicated helper modules, harden AI moderation and polling features, and enhance localization, helpers, and tests while preserving the public API.

New Features:
- Persist poll state per guild with automatic view re-registration and timer resumption across restarts, including deterministic button IDs and updated poll embeds.
- Introduce reusable helper modules for building and registering slash and context menu callbacks and for scanning plugin methods, enabling cleaner bot composition.
- Add locale helper modules for normalization, detection, diagnostics, and translation validation, structuring the i18n system into focused components.

Bug Fixes:
- Mitigate prompt injection in AI moderation by structurally delimiting user content and author identifiers in the LLM analysis prompt.
- Prevent runtime errors by narrowing guild and channel types before use across moderation, AI moderation, starboard, and other plugins, and by guarding guild-only commands.
- Improve tool registration robustness by validating tool config types before registration in the helper utilities.

Enhancements:
- Move polls to per-guild persistent storage with resumable timers, sendable-channel checks, and richer tests covering restart and overdue scenarios.
- Simplify bot command mixin logic by delegating callback and registration concerns to dedicated helper functions without changing the external behavior.
- Refine localization chain building by delegating locale normalization, chain construction, and validation to extracted helpers while keeping the manager API intact.
- Strengthen various plugins and utilities with clearer error-handling comments, safer task cancellation handling, and explicit type casts to satisfy static analysis.
- Extend testing utilities to better simulate interactions and original responses, improving coverage for polling and other command flows.
- Expand contributor documentation in CLAUDE.md with architecture and testing guidance, including invariants around context usage, tool safety, and channel send patterns.

Documentation:
- Update CLAUDE.md with an architecture quick-reference, testing best practices, and key invariants for commands, AI tools, and channel usage.

Tests:
- Add and update unit tests for poll persistence, view behavior, embed helpers, and plugin restart flows, as well as for duration and tally edge cases.
- Adjust testing helpers to expose original interaction responses and message editing, enabling more realistic command and view tests.