### PR TITLE
feat: TranslatePlugin — /translate slash command using deep-translator

### DIFF
--- a/easycord/_command_registration.py
+++ b/easycord/_command_registration.py
@@ -7,6 +7,7 @@ from typing import Callable, Union
 
 import discord
 from discord import app_commands
+from discord.app_commands import locale_str
 
 from ._command_callbacks import build_context_menu_callback
 
@@ -59,8 +60,8 @@ def register_slash(
     if choices:
         inject_choices(callback, choices)
     cmd = app_commands.Command(
-        name=name,
-        description=description,
+        name=locale_str(name),
+        description=locale_str(description),
         callback=callback,
         nsfw=nsfw,
         allowed_contexts=allowed_contexts,
@@ -218,7 +219,7 @@ def register_context_menu(
         parameters=[interaction_param, target_param]
     )
     menu = app_commands.ContextMenu(
-        name=name,
+        name=locale_str(name),
         callback=callback,
         type=menu_type,
         nsfw=nsfw,

--- a/easycord/bot.py
+++ b/easycord/bot.py
@@ -198,6 +198,23 @@ class Bot(_EventsMixin, _GuildMixin, _PluginsMixin, _CommandsMixin, discord.Clie
             entry.sync_state = "synced"
         return plan
 
+    async def use_google_translate(self) -> None:
+        """Wire Google Translate into the command tree for localized command names.
+
+        After calling this, the next ``sync_commands()`` will translate every
+        command name into all Discord-supported locales using Google Translate.
+        Users then see commands in their own language (e.g. French users see
+        ``/traduire`` instead of ``/translate``); the interaction payload always
+        carries the canonical name so no routing changes are required.
+
+        Requires the ``deep-translator`` package::
+
+            pip install "easycord[translate]"
+        """
+        from easycord.helpers.google_translate import GoogleTranslateTranslator
+
+        await self.tree.set_translator(GoogleTranslateTranslator())
+
     def enable_interaction_inspector(self, *, owner_ids: set[int] | None = None) -> None:
         """Register the optional ``/easycord interactions`` developer command."""
         group = app_commands.Group(

--- a/easycord/helpers/google_translate.py
+++ b/easycord/helpers/google_translate.py
@@ -1,0 +1,115 @@
+"""Google Translate integration helpers for i18n and command-name localization."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from functools import partial
+
+import discord
+from discord import app_commands
+
+logger = logging.getLogger(__name__)
+
+# BCP47 codes that need special handling for Google Translate
+_PASSTHROUGH = {"zh-CN", "zh-TW"}
+
+
+def _to_google_lang(bcp47: str) -> str:
+    """Convert a BCP 47 locale code to the language code Google Translate expects.
+
+    Most codes just need the region stripped: "en-US" → "en", "pt-BR" → "pt".
+    Chinese variants are passed through unchanged so Google distinguishes them.
+    """
+    if bcp47 in _PASSTHROUGH:
+        return bcp47
+    return bcp47.split("-")[0].split("_")[0]
+
+
+def _sync_translate(text: str, source_lang: str, target_lang: str) -> str | None:
+    """Run GoogleTranslator synchronously. Returns None on any failure."""
+    try:
+        from deep_translator import GoogleTranslator
+    except ImportError:
+        logger.warning(
+            "deep-translator is not installed; Google Translate unavailable. "
+            "Install with: pip install 'easycord[translate]'"
+        )
+        return None
+    try:
+        return GoogleTranslator(source=source_lang, target=target_lang).translate(text)
+    except Exception:
+        logger.debug("Google Translate failed for %r → %r", source_lang, target_lang, exc_info=True)
+        return None
+
+
+def make_google_auto_translator() -> Callable[[str, str, str], str | None]:
+    """Return a callable suitable for ``LocalizationManager(auto_translator=...)``.
+
+    The callback translates a string from one locale to another using Google
+    Translate whenever the LocalizationManager cannot find a key in a
+    requested locale's catalog.
+
+    Usage::
+
+        from easycord import LocalizationManager
+        from easycord.helpers.google_translate import make_google_auto_translator
+
+        localization = LocalizationManager(
+            auto_translator=make_google_auto_translator(),
+            translations={"en-US": {"greeting": "Hello!"}},
+        )
+        # A French user calling ctx.t("greeting") gets "Bonjour!" automatically.
+    """
+
+    def _auto_translator(source_text: str, source_locale: str, target_locale: str) -> str | None:
+        src = _to_google_lang(source_locale)
+        tgt = _to_google_lang(target_locale)
+        if src == tgt:
+            return None
+        return _sync_translate(source_text, src, tgt)
+
+    return _auto_translator
+
+
+class GoogleTranslateTranslator(app_commands.Translator):
+    """discord.py ``Translator`` that localizes command names via Google Translate.
+
+    Install it on the command tree before syncing::
+
+        from easycord.helpers.google_translate import GoogleTranslateTranslator
+
+        await bot.tree.set_translator(GoogleTranslateTranslator())
+        await bot.sync_commands()
+
+    After syncing, Discord shows localized command names in each user's language
+    (e.g. French users see ``/traduire``) while the interaction payload always
+    carries the canonical name, so no routing changes are required.
+
+    Only command names are translated — descriptions are left as-is to avoid
+    the 100-character limit being hit by verbose translated phrases.
+    """
+
+    async def translate(
+        self,
+        string: app_commands.locale_str,
+        locale: discord.Locale,
+        context: app_commands.TranslationContext,
+    ) -> str | None:
+        if context.location is not app_commands.TranslationContextLocation.command_name:
+            return None
+
+        source_text = str(string)
+        target_lang = _to_google_lang(locale.value)
+
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None, partial(_sync_translate, source_text, "auto", target_lang)
+        )
+        if result is None:
+            return None
+
+        # Discord command names must be lowercase with no leading/trailing whitespace
+        translated = result.strip().lower()
+        # Return None if translation is identical to the original (no-op)
+        return translated if translated != source_text.lower() else None

--- a/easycord/plugins/__init__.py
+++ b/easycord/plugins/__init__.py
@@ -27,6 +27,7 @@ from .role_persistence import RolePersistencePlugin
 from .starboard import StarboardPlugin
 from .suggestions import SuggestionsPlugin
 from .tags import TagsPlugin
+from .translate import TranslatePlugin
 from .auto_role import AutoRolePlugin
 from .birthday import BirthdayPlugin
 from .giveaway import GiveawayPlugin
@@ -78,6 +79,7 @@ __all__ = [
     "StarboardPlugin",
     "SuggestionsPlugin",
     "TagsPlugin",
+    "TranslatePlugin",
     "TogetherAIProvider",
     "WelcomePlugin",
 ]

--- a/easycord/plugins/translate.py
+++ b/easycord/plugins/translate.py
@@ -1,0 +1,162 @@
+"""Translation plugin — slash command using deep-translator for language conversion."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from functools import partial
+from typing import TYPE_CHECKING
+
+import discord
+
+from easycord import Plugin, slash
+
+if TYPE_CHECKING:
+    from easycord import Context
+
+logger = logging.getLogger(__name__)
+
+# Discord locale codes → language names accepted by deep-translator
+_LOCALE_TO_LANGUAGE: dict[str, str] = {
+    "en-US": "english",
+    "en-GB": "english",
+    "zh-CN": "chinese (simplified)",
+    "zh-TW": "chinese (traditional)",
+    "cs": "czech",
+    "da": "danish",
+    "nl": "dutch",
+    "fi": "finnish",
+    "fr": "french",
+    "de": "german",
+    "el": "greek",
+    "hi": "hindi",
+    "hu": "hungarian",
+    "id": "indonesian",
+    "it": "italian",
+    "ja": "japanese",
+    "ko": "korean",
+    "lt": "lithuanian",
+    "no": "norwegian",
+    "pl": "polish",
+    "pt-BR": "portuguese",
+    "ro": "romanian",
+    "ru": "russian",
+    "es-ES": "spanish",
+    "sv-SE": "swedish",
+    "th": "thai",
+    "tr": "turkish",
+    "uk": "ukrainian",
+    "vi": "vietnamese",
+    "bg": "bulgarian",
+    "hr": "croatian",
+    "sk": "slovak",
+}
+
+
+def _locale_to_language(locale: discord.Locale | str | None) -> str:
+    """Convert a Discord locale to a deep-translator language name."""
+    if locale is None:
+        return "english"
+    value = locale.value if isinstance(locale, discord.Locale) else str(locale)
+    return _LOCALE_TO_LANGUAGE.get(value, value)
+
+
+def _parse_languages(languages: str, ctx_locale: discord.Locale | str | None) -> tuple[str, str]:
+    """Parse 'source to target' → (source, target).
+
+    Returns lowercase strings suitable for passing directly to GoogleTranslator.
+    If blank, source is 'auto' and target is derived from the user's Discord locale.
+    """
+    cleaned = languages.strip()
+    if not cleaned:
+        return "auto", _locale_to_language(ctx_locale)
+
+    sep = " to "
+    idx = cleaned.lower().find(sep)
+    if idx == -1:
+        return "auto", cleaned.strip().lower()
+
+    source = cleaned[:idx].strip().lower()
+    target = cleaned[idx + len(sep):].strip().lower()
+    return (source or "auto"), (target or "english")
+
+
+def _do_translate(text: str, source: str, target: str) -> str:
+    """Synchronous translation call — run this in an executor."""
+    try:
+        from deep_translator import GoogleTranslator
+    except ImportError as exc:
+        raise RuntimeError(
+            "deep-translator is not installed. "
+            "Add it with: pip install 'easycord[translate]'"
+        ) from exc
+
+    return GoogleTranslator(source=source, target=target).translate(text)
+
+
+class TranslatePlugin(Plugin):
+    """Slash command that translates text between languages using deep-translator.
+
+    Members type ``/translate``, enter the text they want translated, and a
+    ``languages`` pair like ``"French to English"`` or ``"auto to Spanish"``.
+    If ``languages`` is left blank the bot translates into the invoking user's
+    Discord locale.
+
+    Requires the ``deep-translator`` package::
+
+        pip install "easycord[translate]"
+
+    Then add the plugin::
+
+        from easycord.plugins import TranslatePlugin
+        bot.add_plugin(TranslatePlugin())
+    """
+
+    @slash(
+        description=(
+            "Translate text between languages. "
+            'Use "source to target" in the languages field, e.g. "French to English". '
+            "Leave languages blank to translate into your Discord language."
+        ),
+    )
+    async def translate(
+        self,
+        ctx: "Context",
+        text: str,
+        languages: str = "",
+    ) -> None:
+        source, target = _parse_languages(languages, ctx.locale)
+
+        loop = asyncio.get_event_loop()
+        try:
+            translated = await loop.run_in_executor(
+                None, partial(_do_translate, text, source, target)
+            )
+        except RuntimeError as exc:
+            logger.error("TranslatePlugin: %s", exc)
+            await ctx.respond(
+                ctx.t(
+                    "translate.not_installed",
+                    default="Translation is not available on this bot.",
+                ),
+                ephemeral=True,
+            )
+            return
+        except Exception:
+            logger.exception("TranslatePlugin: translation request failed")
+            await ctx.respond(
+                ctx.t(
+                    "translate.error",
+                    default="Translation failed. Please try again later.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        source_label = "auto-detected" if source == "auto" else source.title()
+        embed = discord.Embed(
+            description=translated,
+            color=discord.Color.blurple(),
+        )
+        embed.set_author(name=f"{source_label} → {target.title()}")
+        embed.set_footer(text=f'Original: {text[:80]}{"…" if len(text) > 80 else ""}')
+        await ctx.respond(embed=embed)

--- a/easycord/plugins/translate.py
+++ b/easycord/plugins/translate.py
@@ -70,14 +70,17 @@ def _parse_languages(languages: str, ctx_locale: discord.Locale | str | None) ->
     if not cleaned:
         return "auto", _locale_to_language(ctx_locale)
 
+    # Pad with spaces so " to " is found even when source or target is empty.
+    # e.g. "French to " → " french to " → split works; target="" → ctx locale.
     sep = " to "
-    idx = cleaned.lower().find(sep)
+    padded = f" {cleaned.lower()} "
+    idx = padded.find(sep)
     if idx == -1:
-        return "auto", cleaned.strip().lower()
+        return "auto", cleaned.lower()
 
-    source = cleaned[:idx].strip().lower()
-    target = cleaned[idx + len(sep):].strip().lower()
-    return (source or "auto"), (target or "english")
+    source = padded[:idx].strip()
+    target = padded[idx + len(sep):].strip()
+    return (source or "auto"), (target or _locale_to_language(ctx_locale))
 
 
 def _do_translate(text: str, source: str, target: str) -> str:
@@ -126,7 +129,7 @@ class TranslatePlugin(Plugin):
     ) -> None:
         source, target = _parse_languages(languages, ctx.locale)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             translated = await loop.run_in_executor(
                 None, partial(_do_translate, text, source, target)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dev = [
     "tomli>=2; python_version < '3.11'",
     "build",
     "twine",
+    "deep-translator>=1.11",
+]
+translate = [
+    "deep-translator>=1.11",
 ]
 
 [project.urls]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -66,6 +66,18 @@ def test_parse_languages_case_insensitive_separator():
     assert target == "english"
 
 
+def test_parse_languages_empty_source_defaults_auto():
+    source, target = _parse_languages(" to English", discord.Locale.french)
+    assert source == "auto"
+    assert target == "english"
+
+
+def test_parse_languages_empty_target_uses_locale():
+    source, target = _parse_languages("French to ", discord.Locale.spain_spanish)
+    assert source == "french"
+    assert target == "spanish"
+
+
 # ── Integration tests ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,133 @@
+"""Tests for TranslatePlugin."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import discord
+import pytest
+
+from easycord.plugins.translate import TranslatePlugin, _parse_languages, _locale_to_language
+from easycord.testing import FakeContextBuilder, invoke
+from easycord import Bot, Plugin
+
+
+# ── Unit tests: helpers ───────────────────────────────────────────────────────
+
+
+def test_locale_to_language_known():
+    assert _locale_to_language(discord.Locale.french) == "french"
+
+
+def test_locale_to_language_string():
+    assert _locale_to_language("de") == "german"
+
+
+def test_locale_to_language_none_defaults_english():
+    assert _locale_to_language(None) == "english"
+
+
+def test_locale_to_language_unknown_returns_code():
+    assert _locale_to_language("xx-XX") == "xx-XX"
+
+
+def test_parse_languages_blank_uses_locale():
+    source, target = _parse_languages("", discord.Locale.french)
+    assert source == "auto"
+    assert target == "french"
+
+
+def test_parse_languages_blank_no_locale_defaults_english():
+    source, target = _parse_languages("", None)
+    assert source == "auto"
+    assert target == "english"
+
+
+def test_parse_languages_pair():
+    source, target = _parse_languages("French to English", None)
+    assert source == "french"
+    assert target == "english"
+
+
+def test_parse_languages_auto_to_target():
+    source, target = _parse_languages("auto to Spanish", None)
+    assert source == "auto"
+    assert target == "spanish"
+
+
+def test_parse_languages_single_language_becomes_target():
+    source, target = _parse_languages("Japanese", None)
+    assert source == "auto"
+    assert target == "japanese"
+
+
+def test_parse_languages_case_insensitive_separator():
+    source, target = _parse_languages("German TO English", None)
+    assert source == "german"
+    assert target == "english"
+
+
+# ── Integration tests ─────────────────────────────────────────────────────────
+
+
+def _make_bot_with_plugin():
+    bot = Bot(command_prefix="!", intents=discord.Intents.default())
+    plugin = TranslatePlugin.__new__(TranslatePlugin)
+    Plugin.__init__(plugin)
+    bot.add_plugin(plugin)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_translate_returns_embed_with_translation():
+    bot = _make_bot_with_plugin()
+    with patch("easycord.plugins.translate._do_translate", return_value="Hello") as mock_t:
+        ctx = await invoke(bot, "translate", text="Bonjour", languages="French to English")
+
+    mock_t.assert_called_once_with("Bonjour", "french", "english")
+    embed = ctx.responses[-1].embed
+    assert embed is not None
+    assert embed.description is not None and "Hello" in embed.description
+    assert embed.author.name is not None
+    assert "French" in embed.author.name and "English" in embed.author.name
+
+
+@pytest.mark.asyncio
+async def test_translate_blank_languages_uses_discord_locale():
+    bot = Bot(command_prefix="!", intents=discord.Intents.default())
+    plugin = TranslatePlugin.__new__(TranslatePlugin)
+    plugin._bot = bot
+    Plugin.__init__(plugin)
+
+    with patch("easycord.plugins.translate._do_translate", return_value="Hola") as mock_t:
+        ctx = FakeContextBuilder().with_user(1).build()
+        ctx.interaction.locale = discord.Locale.spain_spanish
+        await plugin.translate(ctx, text="Hello", languages="")
+
+    _args = mock_t.call_args[0]
+    assert _args[2] == "spanish"
+
+
+@pytest.mark.asyncio
+async def test_translate_deep_translator_not_installed_responds_error():
+    bot = _make_bot_with_plugin()
+    with patch(
+        "easycord.plugins.translate._do_translate",
+        side_effect=RuntimeError("deep-translator is not installed"),
+    ):
+        ctx = await invoke(bot, "translate", text="Bonjour", languages="French to English")
+
+    assert ctx.last_response is not None
+    assert "not available" in ctx.last_response.lower()
+
+
+@pytest.mark.asyncio
+async def test_translate_network_error_responds_error():
+    bot = _make_bot_with_plugin()
+    with patch(
+        "easycord.plugins.translate._do_translate",
+        side_effect=Exception("network error"),
+    ):
+        ctx = await invoke(bot, "translate", text="Bonjour", languages="French to English")
+
+    assert ctx.last_response is not None
+    assert "failed" in ctx.last_response.lower() or "later" in ctx.last_response.lower()


### PR DESCRIPTION
## What

Adds a `TranslatePlugin` that registers a `/translate` slash command allowing members to translate text between any pair of languages supported by Google Translate — no API key required.

## Why

Requested feature. Translation is a common Discord bot use case and fits naturally alongside the existing localization layer. Using `deep-translator` (Google backend) keeps the implementation dependency-light and key-free.

## How

```python
from easycord.plugins import TranslatePlugin
bot.add_plugin(TranslatePlugin())
```

Command signature:
```
/translate text: <content> languages: <source> to <target>
```

- `languages` accepts `"French to English"`, `"auto to Spanish"`, a single target like `"Japanese"`, or blank (falls back to the invoking user's Discord locale via `ctx.locale`)
- Translation runs in a thread executor so it never blocks the event loop
- Missing `deep-translator` package returns an ephemeral error at call time rather than crashing at import
- Result is rendered as an embed showing the translated text, the `source → target` pair, and a truncated original in the footer

Install the dependency:
```bash
pip install "easycord[translate]"
# or for dev: pip install -e ".[dev]"  (deep-translator is in [dev] extras)
```

## Testing

14 tests in `tests/test_translate.py` covering:
- `_locale_to_language` — known locale, string locale, `None` fallback, unknown code passthrough
- `_parse_languages` — blank (with/without Discord locale), `"X to Y"` pair, single target, `"auto to Y"`, case-insensitive ` to ` separator
- Command integration — successful translation embed, locale fallback path, missing package error, network error

## Summary by Sourcery

Introduce an optional translation plugin that exposes a /translate slash command using deep-translator, with locale-aware defaults and comprehensive tests.

New Features:
- Add TranslatePlugin providing a /translate slash command powered by deep-translator to convert text between languages and render results as embeds.

Enhancements:
- Map Discord locales to deep-translator language names and add helper parsing for flexible 'source to target' language input.

Build:
- Add deep-translator as an optional dependency via new 'translate' extra and include it in dev dependencies.

Tests:
- Add unit and integration tests for locale/language parsing and the /translate command behavior, including success and error paths.