### PR TITLE
chore(release): v5.49.0 — TranslatePlugin + Google Translate i18n integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## EasyCord v5.49.0 - 2026-06-20
+
+### Added
+
+**TranslatePlugin** — new `/translate` slash command backed by Google Translate (via `deep-translator`, no API key required):
+- `text` — content to translate
+- `languages` — `"source to target"` pair (e.g. `"French to English"`, `"auto to Spanish"`); blank to auto-translate into the invoking user's Discord locale
+- Translation runs in a thread executor (non-blocking); missing package or network failure returns an ephemeral error
+
+**Google Translate → LocalizationManager** (`easycord/helpers/google_translate.py`):
+- `make_google_auto_translator()` — returns a callback for `LocalizationManager(auto_translator=...)` so missing-key lookups are translated on-the-fly instead of falling back to the default locale's English strings
+- `GoogleTranslateTranslator(app_commands.Translator)` — discord.py's official translator protocol; translates command names to all supported Discord locales at sync time
+
+**Localized command names** — command names and descriptions now wrapped in `locale_str()` at registration time:
+- `bot.use_google_translate()` installs `GoogleTranslateTranslator` on the command tree
+- After `sync_commands()`, Discord shows each user the command in their own language (e.g. `/traduire` for French users, `/übersetzen` for German users)
+- Interaction payload always carries the canonical name — no routing changes needed
+
+**New optional extra:**
+```bash
+pip install "easycord[translate]"   # pulls in deep-translator
+pip install -e ".[dev]"             # dev installs include it automatically
+```
+
+### Fixed
+
+- `_parse_languages`: empty source or target after the `" to "` separator now correctly falls back to the user's Discord locale (was hardcoded to `"english"`)
+- `_parse_languages`: padding trick fixes edge cases where `str.strip()` removes the spaces that form the separator (`" to English"` and `"French to "`)
+- `asyncio.get_running_loop()` replaces deprecated `asyncio.get_event_loop()` in `TranslatePlugin.translate`
+
 ## EasyCord v5.48.0 - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,19 @@ Refer to [AGENTS.md](AGENTS.md) for detailed framework conventions.
 
 Release links: [v5.49.0 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.49.0) · [Changelog](CHANGELOG.md)
 
-## New in v5.46.0 (Current Release)
+## New in v5.49.0 (Current Release)
+
+**TranslatePlugin** — `/translate` slash command backed by Google Translate (no API key required):
+- `text` — content to translate
+- `languages` — `"French to English"`, `"auto to Spanish"`, or blank to translate into the invoking user's Discord locale
+
+**Google Translate → LocalizationManager:**
+- `make_google_auto_translator()` for `LocalizationManager(auto_translator=...)` — missing-key lookups are translated on-the-fly and cached
+- `GoogleTranslateTranslator(app_commands.Translator)` — discord.py translator protocol; after `bot.use_google_translate()` + `sync_commands()`, Discord shows localized command names per locale
+
+**Localized command routing:** `locale_str()` wrapping on all registered command names; French users see `/traduire`, German `/übersetzen`, etc. — all route to the same handler.
+
+## Previous: v5.46.0
 
 **Pylance type fixes:**
 - `context_builder.py`: safe `getattr` for `ContextMenu.description` — ContextMenu commands don't have a `description` attribute.
@@ -128,11 +140,6 @@ Release links: [v5.49.0 release](https://github.com/rolling-codes/EasyCord/relea
 - Stress/concurrency tests for `rate_limit`, `ConversationMemory`, `LocalizationManager`.
 - Unit tests for 8 previously-untested plugins: starboard, suggestions, reaction_roles, moderation, polls, tags, invite_tracker, member_logging.
 - Unit tests for zero-coverage core modules: `EmbedCard`, formatters, `ContextBuilder`, `SlashGroup`, `SecurityManager`, `FrameworkManager`, `AuditLog`.
-
-**Verification:**
-- `python scripts/check_release_metadata.py`
-- `pytest` - 744 passed.
-- `ruff check easycord tests --select E9,F63,F7,F82`
 
 ## Previous: v5.43.0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EasyCord
-![Version](https://img.shields.io/badge/v-5.48.0-blue)
+![Version](https://img.shields.io/badge/v-5.49.0-blue)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-passing-brightgreen)
@@ -114,7 +114,7 @@ async def test_my_logic():
 For more, see [examples/](examples/) and [docs/](docs/).
 Refer to [AGENTS.md](AGENTS.md) for detailed framework conventions.
 
-Release links: [v5.48.0 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.48.0) · [Changelog](CHANGELOG.md)
+Release links: [v5.49.0 release](https://github.com/rolling-codes/EasyCord/releases/tag/v5.49.0) · [Changelog](CHANGELOG.md)
 
 ## New in v5.46.0 (Current Release)
 
@@ -313,7 +313,7 @@ bot = (
 ### From GitHub (via pip)
 
 ```bash
-pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.48.0/easycord-5.48.0-py3-none-any.whl"
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.49.0/easycord-5.49.0-py3-none-any.whl"
 ```
 
 ### Clone and install locally

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.48.0/easycord-5.48.0-py3-none-any.whl"
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.49.0/easycord-5.49.0-py3-none-any.whl"
 ```
 
 Or clone and install locally:

--- a/easycord/__init__.py
+++ b/easycord/__init__.py
@@ -16,7 +16,7 @@ Quick start::
     bot.run("YOUR_TOKEN")
 """
 
-__version__ = "5.48.0"
+__version__ = "5.49.0"
 
 from .audit import AuditLog
 from .bot import Bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "easycord"
-version = "5.48.0"
+version = "5.49.0"
 description = "Production-grade Discord bot framework with AI orchestration, multi-provider LLMs, and permission-gated tool execution"
 readme = "README.md"
 license = "MIT"
@@ -48,8 +48,8 @@ Homepage       = "https://github.com/rolling-codes/EasyCord"
 Repository     = "https://github.com/rolling-codes/EasyCord"
 Issues         = "https://github.com/rolling-codes/EasyCord/issues"
 Documentation  = "https://github.com/rolling-codes/EasyCord"
-Download       = "https://github.com/rolling-codes/EasyCord/releases/download/v5.48.0/easycord-5.48.0-py3-none-any.whl"
-Release        = "https://github.com/rolling-codes/EasyCord/releases/tag/v5.48.0"
+Download       = "https://github.com/rolling-codes/EasyCord/releases/download/v5.49.0/easycord-5.49.0-py3-none-any.whl"
+Release        = "https://github.com/rolling-codes/EasyCord/releases/tag/v5.49.0"
 Changelog      = "https://github.com/rolling-codes/EasyCord/blob/main/CHANGELOG.md"
 
 [project.scripts]

--- a/release_v5.49.0/notes.md
+++ b/release_v5.49.0/notes.md
@@ -1,0 +1,73 @@
+# EasyCord v5.49.0 Release Notes
+
+Minor feature release — `/translate` slash command, Google Translate wired into the localization core, and automatic localized command names.
+
+---
+
+## Added
+
+### TranslatePlugin — `/translate` slash command
+
+```python
+from easycord.plugins import TranslatePlugin
+bot.add_plugin(TranslatePlugin())
+```
+
+Members type `/translate`, enter the text to translate, and a `"source to target"` language pair:
+
+```
+/translate text: Bonjour tout le monde  languages: French to English
+→  Hello everyone
+
+/translate text: Hello  languages: auto to Japanese
+→  こんにちは
+
+/translate text: Guten Morgen  languages:
+→  (translated into the user's Discord locale automatically)
+```
+
+Requires `deep-translator`:
+```bash
+pip install "easycord[translate]"
+```
+
+---
+
+### Google Translate → LocalizationManager
+
+```python
+from easycord import LocalizationManager
+from easycord.helpers.google_translate import make_google_auto_translator
+
+localization = LocalizationManager(
+    auto_translator=make_google_auto_translator(),
+    translations={"en-US": {"greeting": "Hello!", "farewell": "Goodbye!"}},
+)
+# French user: ctx.t("greeting") → "Bonjour!" (auto-translated, cached)
+# Japanese user: ctx.t("farewell") → "さようなら" (auto-translated, cached)
+```
+
+---
+
+### Localized command names
+
+After installing the translator and syncing, Discord shows each user commands in their own language:
+
+```python
+await bot.use_google_translate()   # installs GoogleTranslateTranslator on tree
+await bot.sync_commands()          # Discord fetches localized names for all locales
+```
+
+French users see `/traduire`, German users see `/übersetzen`, Japanese users see `/翻訳する` — all routing to the same `/translate` handler. The interaction payload always carries the canonical English name, so no bot-side routing changes are needed.
+
+---
+
+## Install
+
+```bash
+# Wheel
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.49.0/easycord-5.49.0-py3-none-any.whl"
+
+# Source distribution
+pip install "https://github.com/rolling-codes/EasyCord/releases/download/v5.49.0/easycord-5.49.0.tar.gz"
+```

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -98,15 +97,15 @@ def bump(new_version: str, *, dry_run: bool = False) -> int:
         print(f"  updated: {path.relative_to(ROOT)}")
 
     # Validate immediately so the caller knows if anything was missed
-    result = subprocess.run(
-        [sys.executable, str(ROOT / "scripts" / "check_release_metadata.py")],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        print("\ncheck_release_metadata.py found issues after bump:", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-        return result.returncode
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from check_release_metadata import collect_errors  # type: ignore[import]
+
+    errors = collect_errors(ROOT)
+    if errors:
+        print("\ncheck_release_metadata found issues after bump:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
 
     print(f"\nBumped {old_version} → {new_version}. Metadata check passed.")
     return 0

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,124 @@
+"""Bump EasyCord's version across all files that check_release_metadata.py validates.
+
+Usage:
+    python scripts/bump_version.py 5.50.0
+    python scripts/bump_version.py 5.50.0 --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-.][A-Za-z0-9.]+)?$")
+ROOT = Path(__file__).resolve().parents[1]
+GITHUB_REPO = "https://github.com/rolling-codes/EasyCord"
+
+
+def _asset_urls(version: str) -> dict[str, str]:
+    tag = f"v{version}"
+    base = f"{GITHUB_REPO}/releases/download/{tag}"
+    wheel = f"easycord-{version}-py3-none-any.whl"
+    sdist = f"easycord-{version}.tar.gz"
+    return {
+        "tag": tag,
+        "wheel": wheel,
+        "sdist": sdist,
+        "wheel_url": f"{base}/{wheel}",
+        "sdist_url": f"{base}/{sdist}",
+        "release_url": f"{GITHUB_REPO}/releases/tag/{tag}",
+    }
+
+
+def _current_version() -> str:
+    pyproject = ROOT / "pyproject.toml"
+    for line in pyproject.read_text(encoding="utf-8").splitlines():
+        m = re.match(r'^version\s*=\s*"([^"]+)"', line.strip())
+        if m:
+            return m.group(1)
+    raise RuntimeError("Could not find version in pyproject.toml")
+
+
+def _replace_all(text: str, old: str, new: str) -> str:
+    return text.replace(old, new)
+
+
+def bump(new_version: str, *, dry_run: bool = False) -> int:
+    if not VERSION_RE.fullmatch(new_version):
+        print(f"Error: {new_version!r} is not a valid semver string.", file=sys.stderr)
+        return 1
+
+    old_version = _current_version()
+    if old_version == new_version:
+        print(f"Already at {new_version}; nothing to do.")
+        return 0
+
+    old = _asset_urls(old_version)
+    new = _asset_urls(new_version)
+
+    substitutions: list[tuple[str, str]] = [
+        (old_version, new_version),
+        (old["tag"], new["tag"]),
+        (old["wheel"], new["wheel"]),
+        (old["sdist"], new["sdist"]),
+        (old["wheel_url"], new["wheel_url"]),
+        (old["sdist_url"], new["sdist_url"]),
+        (old["release_url"], new["release_url"]),
+    ]
+
+    targets = [
+        ROOT / "pyproject.toml",
+        ROOT / "easycord" / "__init__.py",
+        ROOT / "README.md",
+        ROOT / "docs" / "getting-started.md",
+    ]
+
+    changed: list[tuple[Path, str]] = []
+    for path in targets:
+        original = path.read_text(encoding="utf-8")
+        updated = original
+        for old_str, new_str in substitutions:
+            updated = _replace_all(updated, old_str, new_str)
+        if updated != original:
+            changed.append((path, updated))
+
+    if not changed:
+        print(f"No version strings found for {old_version!r} in tracked files.")
+        return 1
+
+    if dry_run:
+        for path, _ in changed:
+            print(f"  would update: {path.relative_to(ROOT)}")
+        return 0
+
+    for path, content in changed:
+        path.write_text(content, encoding="utf-8")
+        print(f"  updated: {path.relative_to(ROOT)}")
+
+    # Validate immediately so the caller knows if anything was missed
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_release_metadata.py")],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("\ncheck_release_metadata.py found issues after bump:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return result.returncode
+
+    print(f"\nBumped {old_version} → {new_version}. Metadata check passed.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="New version string, e.g. 5.50.0")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change without writing")
+    args = parser.parse_args(argv)
+    return bump(args.version, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Minor feature release shipping the work from PR #60.

- **TranslatePlugin** — `/translate` slash command backed by Google Translate; `"source to target"` language pair or blank to auto-detect from the user's Discord locale
- **`make_google_auto_translator()`** — plug directly into `LocalizationManager(auto_translator=...)` for on-the-fly key translation; results are cached in the catalog
- **`GoogleTranslateTranslator`** — discord.py `Translator` subclass; after `bot.use_google_translate()` + `sync_commands()`, Discord shows localized command names per locale (`/traduire` for FR, `/übersetzen` for DE, etc.)
- **`locale_str()` wrapping** — command names and descriptions now registered as `locale_str` so the translator protocol fires at sync time

## Checklist

- [x] `python scripts/check_release_metadata.py` passes
- [x] 1025 tests passing (`pytest tests/ -x -q`)
- [x] Version bumped to `5.49.0` in `pyproject.toml`, `__init__.py`, `README.md`, `docs/getting-started.md`
- [x] `CHANGELOG.md` entry added
- [x] `release_v5.49.0/notes.md` created
- [ ] Tag `v5.49.0` after merge
- [ ] GitHub release created after tag

## Summary by Sourcery

Release EasyCord v5.49.0 with Google Translate-powered translation features, including a /translate command, automatic localization support, and updated version metadata and documentation.

New Features:
- Introduce TranslatePlugin providing a /translate slash command backed by Google Translate via deep-translator.
- Add Google Translate integration for LocalizationManager to auto-translate missing localization keys and cache results.
- Enable localized command names and descriptions using Discord's translator protocol and locale_str-based registration.
- Provide an optional translate extra to install deep-translator dependencies.

Bug Fixes:
- Improve language pair parsing in _parse_languages, correctly falling back to the user's Discord locale and handling edge-case separators.
- Replace deprecated asyncio.get_event_loop usage in TranslatePlugin.translate with asyncio.get_running_loop.

Documentation:
- Document the new translation features and usage patterns in CHANGELOG and dedicated v5.49.0 release notes.
- Update README and getting-started installation URLs and badges for version 5.49.0.

Chores:
- Bump project version metadata and distribution links from 5.48.0 to 5.49.0.